### PR TITLE
Show real commission values

### DIFF
--- a/src/pages/stake/Validators.tsx
+++ b/src/pages/stake/Validators.tsx
@@ -187,7 +187,7 @@ const Validators = () => {
               { commission: { commission_rates: b } }
             ) => a.rate.toNumber() - b.rate.toNumber(),
             render: ({ rate }: Validator.CommissionRates) =>
-              readPercent(rate.toString(), { fixed: 1 }),
+              readPercent(rate.toString(), { fixed: 2 }),
             align: "right",
           },
           {


### PR DESCRIPTION
Many validators use double digit decimal commissions; this change is just to accurately represent those validators commissions on the main staking page.