### PR TITLE
Handle ledger status code 27404

### DIFF
--- a/src/auth/ledger/ledger.ts
+++ b/src/auth/ledger/ledger.ts
@@ -115,7 +115,7 @@ const checkLedgerErrors = (response: CommonResponse | null) => {
       throw new LedgerError("Ledger's screensaver mode is on")
       
     case "Unknown Status Code: 27404":
-      throw new LedgerError("Ledger's screensaver mode is on")
+      throw new LedgerError("Ledger is locked")
 
     case "Instruction not supported":
       throw new LedgerError(

--- a/src/auth/ledger/ledger.ts
+++ b/src/auth/ledger/ledger.ts
@@ -113,6 +113,9 @@ const checkLedgerErrors = (response: CommonResponse | null) => {
 
     case "Unknown Status Code: 26628":
       throw new LedgerError("Ledger's screensaver mode is on")
+      
+    case "Unknown Status Code: 27404":
+      throw new LedgerError("Ledger's screensaver mode is on")
 
     case "Instruction not supported":
       throw new LedgerError(


### PR DESCRIPTION
`Unknown Status Code: 27404` appears when, while trying to sign a transaction, the ledger is on the screensaver and needs to be unlocked