### PR TITLE
Add advanced settings to ledger form

### DIFF
--- a/src/auth/ledger/AccessWithLedgerForm.tsx
+++ b/src/auth/ledger/AccessWithLedgerForm.tsx
@@ -8,12 +8,51 @@ import { FormError } from "components/form"
 import useAuth from "../hooks/useAuth"
 import * as ledger from "./ledger"
 
+const TERRA_DEFAULT_PATH = [44, 118, 0, 0, 0]
+const COSMOS_DEFAULT_PATH = [44, 330, 0, 0, 0]
+
 const AccessWithLedgerForm = () => {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const { connectLedger } = useAuth()
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<Error>()
+  const [showAdvancedSettings, setShowAdvancedSettings] = useState(false)
+  const [customDerivationIsEnabled, setCustomDerivationIsEnabled] =
+    useState(false)
+  const [appInteger, setAppInteger] = useState(118)
+  const [pathState, setPathState] = useState(TERRA_DEFAULT_PATH)
+
+  const handleDerivation = (e: React.ChangeEvent) => {
+    let target = e.target as HTMLElement
+    let tid = target.id
+    let targetValue = 0
+    let pathIdx = 0
+    switch (tid) {
+      case "path1":
+        targetValue = parseInt((target as HTMLSelectElement).value)
+        setAppInteger(targetValue)
+        pathIdx = 1
+        break
+      case "path2":
+        pathIdx = 2
+        targetValue = parseInt((target as HTMLInputElement).value)
+        break
+      case "path3":
+        pathIdx = 3
+        targetValue = parseInt((target as HTMLInputElement).value)
+        break
+      case "path4":
+        pathIdx = 4
+        targetValue = parseInt((target as HTMLInputElement).value)
+        break
+    }
+    let newPath = pathState
+    newPath[pathIdx] = targetValue
+    setPathState(newPath)
+
+    console.log(pathState)
+  }
 
   const connect = async () => {
     setIsLoading(true)
@@ -30,20 +69,141 @@ const AccessWithLedgerForm = () => {
     }
   }
 
+  let derivationSelector = (
+    <div style={{ whiteSpace: "nowrap", maxWidth: "50px" }}>
+      <select
+        onChange={handleDerivation}
+        name="path0"
+        id="path0"
+        disabled={!customDerivationIsEnabled}
+      >
+        <option value="44">44</option>
+      </select>
+      /
+      <select
+        onChange={handleDerivation}
+        name="path1"
+        id="path1"
+        disabled={!customDerivationIsEnabled}
+        value={appInteger}
+      >
+        <option value="118">118</option>
+        <option value="330">330</option>
+      </select>
+      /&nbsp;
+      <input
+        onChange={handleDerivation}
+        type="number"
+        name="path2"
+        id="path2"
+        disabled={!customDerivationIsEnabled}
+        defaultValue="0"
+      ></input>
+      /&nbsp;
+      <input
+        onChange={handleDerivation}
+        type="number"
+        name="path3"
+        id="path3"
+        disabled={!customDerivationIsEnabled}
+        defaultValue="0"
+      ></input>
+      /&nbsp;
+      <input
+        onChange={handleDerivation}
+        type="number"
+        name="path4"
+        id="path4"
+        disabled={!customDerivationIsEnabled}
+        defaultValue="0"
+      ></input>
+    </div>
+  )
+
+  let advancedPanel
+  if (showAdvancedSettings) {
+    advancedPanel = (
+      <Grid gap={10} className="text-left">
+        <br></br>
+        <hr
+          style={{ color: "#11AA11", margin: "1px", border: "1px solid grey" }}
+        ></hr>
+        <br></br>
+        <p className="text-left">
+          {t(
+            "It is recommended you only use advanced settings if you know what you are doing. Otherwise, stick with the defaults."
+          )}
+        </p>
+        <h4>Derivation Path:</h4>
+        <div>
+          <select
+            name="derivationPath"
+            onClick={(e) => {
+              const target = e.target as HTMLSelectElement
+              switch (target.value) {
+                case "terraDefaults":
+                  setAppInteger(118)
+                  setPathState(TERRA_DEFAULT_PATH)
+                  setCustomDerivationIsEnabled(false)
+                  break
+                case "cosmosDefaults":
+                  setAppInteger(330)
+                  setPathState(COSMOS_DEFAULT_PATH)
+                  setCustomDerivationIsEnabled(false)
+                  break
+                case "custom":
+                  setCustomDerivationIsEnabled(true)
+                  break
+              }
+            }}
+            defaultValue={"terraDefaults"}
+          >
+            <option value="terraDefaults">Terra Defaults</option>
+            <option value="cosmosDefaults">
+              Cosmos Defaults (Keplr compatible)
+            </option>
+            <option value="custom">Custom</option>
+          </select>
+          <br></br>
+          <br></br>
+          {derivationSelector}
+        </div>
+      </Grid>
+    )
+  } else {
+    // if user closes Advanced Settings, return everything back to defaults
+    if (pathState != TERRA_DEFAULT_PATH) {
+      setPathState(TERRA_DEFAULT_PATH)
+    }
+  }
+
   return (
-    <Grid gap={20} className="center">
-      <p className="center">
-        <UsbIcon style={{ fontSize: 56 }} />
-      </p>
+    <div>
+      <Grid gap={20} className="center">
+        <p className="center">
+          <UsbIcon style={{ fontSize: 56 }} />
+        </p>
 
-      {t("Plug in a Ledger device")}
+        {t("Plug in a Ledger device")}
 
-      {error && <FormError>{error.message}</FormError>}
+        {error && <FormError>{error.message}</FormError>}
 
-      <Button onClick={connect} loading={isLoading} color="primary" block>
-        {t("Connect")}
-      </Button>
-    </Grid>
+        <Button onClick={connect} loading={isLoading} color="primary" block>
+          {t("Connect")}
+        </Button>
+        <a
+          href="#"
+          onClick={() => setShowAdvancedSettings(!showAdvancedSettings)}
+        >
+          {t(
+            showAdvancedSettings
+              ? "Close Advanced Settings"
+              : "Open Advanced Settings"
+          )}
+        </a>
+      </Grid>
+      {advancedPanel}
+    </div>
   )
 }
 

--- a/src/auth/ledger/AccessWithLedgerForm.tsx
+++ b/src/auth/ledger/AccessWithLedgerForm.tsx
@@ -7,9 +7,12 @@ import { Grid } from "components/layout"
 import { FormError } from "components/form"
 import useAuth from "../hooks/useAuth"
 import * as ledger from "./ledger"
-
-const TERRA_DEFAULT_PATH = [44, 118, 0, 0, 0]
-const COSMOS_DEFAULT_PATH = [44, 330, 0, 0, 0]
+import {
+  TERRA_APP_NUMBER,
+  COSMOS_APP_NUMBER,
+  DEFAULT_PATH_TERRA,
+  DEFAULT_PATH_COSMOS,
+} from "./ledger"
 
 const AccessWithLedgerForm = () => {
   const { t } = useTranslation()
@@ -20,8 +23,7 @@ const AccessWithLedgerForm = () => {
   const [showAdvancedSettings, setShowAdvancedSettings] = useState(false)
   const [customDerivationIsEnabled, setCustomDerivationIsEnabled] =
     useState(false)
-  const [appInteger, setAppInteger] = useState(118)
-  const [pathState, setPathState] = useState(TERRA_DEFAULT_PATH)
+  const [pathState, setPathState] = useState([...DEFAULT_PATH_TERRA])
 
   const handleDerivation = (e: React.ChangeEvent) => {
     let target = e.target as HTMLElement
@@ -29,9 +31,10 @@ const AccessWithLedgerForm = () => {
     let targetValue = 0
     let pathIdx = 0
     switch (tid) {
+      case "path0":
+        break
       case "path1":
         targetValue = parseInt((target as HTMLSelectElement).value)
-        setAppInteger(targetValue)
         pathIdx = 1
         break
       case "path2":
@@ -47,11 +50,9 @@ const AccessWithLedgerForm = () => {
         targetValue = parseInt((target as HTMLInputElement).value)
         break
     }
-    let newPath = pathState
+    let newPath = [...pathState]
     newPath[pathIdx] = targetValue
     setPathState(newPath)
-
-    console.log(pathState)
   }
 
   const connect = async () => {
@@ -59,7 +60,7 @@ const AccessWithLedgerForm = () => {
     setError(undefined)
 
     try {
-      const address = await ledger.getTerraAddress()
+      const address = await ledger.getTerraAddress(pathState)
       connectLedger(address)
       navigate("/wallet", { replace: true })
     } catch (error) {
@@ -76,6 +77,7 @@ const AccessWithLedgerForm = () => {
         name="path0"
         id="path0"
         disabled={!customDerivationIsEnabled}
+        value={pathState[0]}
       >
         <option value="44">44</option>
       </select>
@@ -85,7 +87,7 @@ const AccessWithLedgerForm = () => {
         name="path1"
         id="path1"
         disabled={!customDerivationIsEnabled}
-        value={appInteger}
+        value={pathState[1]}
       >
         <option value="118">118</option>
         <option value="330">330</option>
@@ -97,7 +99,7 @@ const AccessWithLedgerForm = () => {
         name="path2"
         id="path2"
         disabled={!customDerivationIsEnabled}
-        defaultValue="0"
+        value={pathState[2]}
       ></input>
       /&nbsp;
       <input
@@ -106,7 +108,7 @@ const AccessWithLedgerForm = () => {
         name="path3"
         id="path3"
         disabled={!customDerivationIsEnabled}
-        defaultValue="0"
+        value={pathState[3]}
       ></input>
       /&nbsp;
       <input
@@ -115,7 +117,7 @@ const AccessWithLedgerForm = () => {
         name="path4"
         id="path4"
         disabled={!customDerivationIsEnabled}
-        defaultValue="0"
+        value={pathState[4]}
       ></input>
     </div>
   )
@@ -138,17 +140,15 @@ const AccessWithLedgerForm = () => {
         <div>
           <select
             name="derivationPath"
-            onClick={(e) => {
+            onChange={(e) => {
               const target = e.target as HTMLSelectElement
               switch (target.value) {
                 case "terraDefaults":
-                  setAppInteger(118)
-                  setPathState(TERRA_DEFAULT_PATH)
+                  setPathState(DEFAULT_PATH_TERRA)
                   setCustomDerivationIsEnabled(false)
                   break
                 case "cosmosDefaults":
-                  setAppInteger(330)
-                  setPathState(COSMOS_DEFAULT_PATH)
+                  setPathState(DEFAULT_PATH_COSMOS)
                   setCustomDerivationIsEnabled(false)
                   break
                 case "custom":
@@ -172,8 +172,11 @@ const AccessWithLedgerForm = () => {
     )
   } else {
     // if user closes Advanced Settings, return everything back to defaults
-    if (pathState != TERRA_DEFAULT_PATH) {
-      setPathState(TERRA_DEFAULT_PATH)
+    if (customDerivationIsEnabled) {
+      setCustomDerivationIsEnabled(false)
+    }
+    if (pathState !== DEFAULT_PATH_TERRA) {
+      setPathState(DEFAULT_PATH_TERRA)
     }
   }
 


### PR DESCRIPTION
The latest change to station and the extension enforce usage of the Terra app. This broke many users workflow; while legacy terra station is available to transfer funds, this would still cause users to have to move their funds around to the new application to use defi or receive the changes and improvements in station going forward. This PR allows users to continue using the Cosmos application with station if they so wish. 

Additionally, this also provides an ability to have multiple addresses via derivation path changes. Among other reasons, given the Void protocol launching in Q1 2022, it will be useful for users to be able to generate multiple unrelated addresses with the same ledger.