### PR TITLE
Fix validation error message for wallet name

### DIFF
--- a/src/auth/scripts/validate.ts
+++ b/src/auth/scripts/validate.ts
@@ -4,7 +4,7 @@ import wordlist from "./wordlist.json"
 const validate = {
   name: {
     alphanumeric: (name: string) =>
-      /^[a-z0-9]+$/.test(name) || "Enter alphanumeric characters",
+      /^[a-z0-9]+$/.test(name) || "Enter lowercase alphanumeric characters",
     length: (name: string) =>
       (name.length >= 3 && name.length <= 20) ||
       "Enter 3-20 alphanumeric characters",


### PR DESCRIPTION
**Issue**
When creating a wallet, the error message is not clear that Uppercase characters are not allowed:
<img width="666" alt="Screenshot 2022-01-19 at 11 58 01" src="https://user-images.githubusercontent.com/497957/150156175-1a903c54-dae5-4503-b976-5be79acaaf93.png">

**Solution**
As I'm not sure that Uppercase names are really allowed, a simple solution for now is to improve the validation for the fields. 

PS: This is my first PR for the terra-money. Please let me know if there are any contribution guidelines.
