### PR TITLE
fix: Swap gas

### DIFF
--- a/src/txs/Tx.tsx
+++ b/src/txs/Tx.tsx
@@ -129,9 +129,10 @@ function Tx<TxValues>(props: Props<TxValues>) {
       const unsignedTx = await lcd.tx.create([{ address }], {
         ...simulationTx,
         feeDenoms: [initialGasDenom],
+        gasAdjustment,
       })
 
-      return Math.ceil(unsignedTx.auth_info.fee.gas_limit * gasAdjustment)
+      return unsignedTx.auth_info.fee.gas_limit
     },
     {
       ...RefetchOptions.INFINITY,


### PR DESCRIPTION
`lcd.tx.create` allows passing the gas adjustment, and defaults to 1.75. Previously, the gas adjustment was getting multiplied by the gas limit causing a fee which should've been 0.4 UST to become 0.7 UST. Since gas isn't refunded, this fix can reduce swap gas by ~50%.