### PR TITLE
Add TNS Reverse Record

### DIFF
--- a/src/app/sections/Connected.tsx
+++ b/src/app/sections/Connected.tsx
@@ -12,12 +12,14 @@ import { isWallet, useAuth } from "auth"
 import SwitchWallet from "auth/modules/select/SwitchWallet"
 import PopoverNone from "../components/PopoverNone"
 import styles from "./Connected.module.scss"
+import { useTnsName } from "data/external/tns"
 
 const Connected = () => {
   const { t } = useTranslation()
   const { disconnect } = useWallet()
   const address = useAddress()
   const { wallet } = useAuth()
+  const { data: name } = useTnsName(address ?? "")
 
   /* hack to close popover */
   const [key, setKey] = useState(0)
@@ -28,6 +30,9 @@ const Connected = () => {
   const footer = wallet
     ? { to: "/auth", onClick: closePopover, children: t("Manage wallets") }
     : { onClick: disconnect, children: t("Disconnect") }
+
+  const displayName =
+    name && name.length >= 20 ? name.substring(0, 20) + "..." : name
 
   return (
     <Popover
@@ -67,7 +72,9 @@ const Connected = () => {
         size="small"
         outline
       >
-        {isWallet.local(wallet) ? wallet.name : truncate(address)}
+        {isWallet.local(wallet)
+          ? wallet.name
+          : displayName || truncate(address)}
       </Button>
     </Popover>
   )

--- a/src/data/Terra/TerraAssets.ts
+++ b/src/data/Terra/TerraAssets.ts
@@ -59,7 +59,12 @@ export const useCW20Pairs = () => {
   return useTerraAssetsByNetwork<CW20Pairs>("cw20/pairs.dex.json")
 }
 
-export type ContractNames = "assertLimitOrder" | "routeswap" | "tnsRegistry"
+export type ContractNames =
+  | "assertLimitOrder"
+  | "routeswap"
+  | "tnsRegistry"
+  | "tnsReverseRecord"
+
 export type TerraContracts = Record<ContractNames, AccAddress>
 export const useTerraContracts = () => {
   return useTerraAssetsByNetwork<TerraContracts>("contracts.json")

--- a/src/data/external/tns.ts
+++ b/src/data/external/tns.ts
@@ -11,7 +11,7 @@ import { useTerraContracts } from "../Terra/TerraAssets"
  * @param name - A TNS identifier such as "alice.ust"
  * @returns The terra address of the specified name, null if not resolvable
  */
-export const useTNS = (name: string) => {
+export const useTnsAddress = (name: string) => {
   const lcd = useLCDClient()
   const { data: contracts } = useTerraContracts()
 
@@ -45,6 +45,34 @@ export const useTNS = (name: string) => {
       return address
     },
     { ...RefetchOptions.INFINITY, enabled: name.endsWith(".ust") }
+  )
+}
+
+/**
+ * Resolve TNS name from a terra address.
+ *
+ * @param address - A terra address
+ * @returns The TNS name of the specified address, null if not resolvable
+ */
+export const useTnsName = (address: string) => {
+  const lcd = useLCDClient()
+  const { data: contracts } = useTerraContracts()
+
+  return useQuery(
+    [queryKey.TNS, address],
+    async () => {
+      if (!contracts || !address) return
+
+      const { tnsReverseRecord: reverseRecord } = contracts
+
+      const { name } = await lcd.wasm.contractQuery<{ name: string | null }>(
+        reverseRecord,
+        { get_name: { address } }
+      )
+
+      return name
+    },
+    { ...RefetchOptions.INFINITY, enabled: Boolean(contracts) }
   )
 }
 

--- a/src/txs/AddressBook/AddAddressBookItem.tsx
+++ b/src/txs/AddressBook/AddAddressBookItem.tsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form"
 import PersonIcon from "@mui/icons-material/Person"
 import { truncate } from "@terra.kitchen/utils"
 import { useAddressBook } from "data/settings/AddressBook"
-import { useTNS } from "data/external/tns"
+import { useTnsAddress } from "data/external/tns"
 import { InlineFlex } from "components/layout"
 import { Form, FormItem, Submit, Input } from "components/form"
 import { Fetching, useModal } from "components/feedback"
@@ -27,7 +27,7 @@ const AddAddressBookItem = () => {
   }
 
   /* resolve recipient */
-  const { data: resolvedAddress, ...tnsState } = useTNS(recipient ?? "")
+  const { data: resolvedAddress, ...tnsState } = useTnsAddress(recipient ?? "")
 
   // validate(tns): not found
   const invalid =

--- a/src/txs/send/SendForm.tsx
+++ b/src/txs/send/SendForm.tsx
@@ -9,7 +9,7 @@ import { SAMPLE_ADDRESS } from "config/constants"
 import { queryKey } from "data/query"
 import { useAddress } from "data/wallet"
 import { useBankBalance } from "data/queries/bank"
-import { useTNS } from "data/external/tns"
+import { useTnsAddress } from "data/external/tns"
 import { ExternalLink } from "components/general"
 import { Auto, Card, Grid, InlineFlex } from "components/layout"
 import { Form, FormItem, FormHelp, Input, FormWarning } from "components/form"
@@ -53,7 +53,7 @@ const SendForm = ({ token, decimals, balance }: Props) => {
   }
 
   /* resolve recipient */
-  const { data: resolvedAddress, ...tnsState } = useTNS(recipient ?? "")
+  const { data: resolvedAddress, ...tnsState } = useTnsAddress(recipient ?? "")
   useEffect(() => {
     if (!recipient) {
       setValue("address", undefined)

--- a/src/txs/wasm/TransferCW721Form.tsx
+++ b/src/txs/wasm/TransferCW721Form.tsx
@@ -9,7 +9,7 @@ import { SAMPLE_ADDRESS } from "config/constants"
 import { queryKey } from "data/query"
 import { useAddress } from "data/wallet"
 import { useBankBalance } from "data/queries/bank"
-import { useTNS } from "data/external/tns"
+import { useTnsAddress } from "data/external/tns"
 import { Auto, Card, InlineFlex } from "components/layout"
 import { Form, FormItem, FormHelp, Input } from "components/form"
 import NFTAssetItem from "pages/nft/NFTAssetItem"
@@ -50,7 +50,7 @@ const TransferCW721Form = ({ contract, id }: Props) => {
   }
 
   /* resolve recipient */
-  const { data: resolvedAddress, ...tnsState } = useTNS(recipient ?? "")
+  const { data: resolvedAddress, ...tnsState } = useTnsAddress(recipient ?? "")
   useEffect(() => {
     if (!recipient) {
       setValue("address", undefined)


### PR DESCRIPTION
Add TNS Reverse Record:
- Show ".ust" name instead of a terra address on the top right
- Rename `useTNS` to `useTnsAddress`
- Add new hook called `useTnsName` (to resolve ".ust" name from a terra address)

![Screen Shot 2565-02-11 at 13 31 36](https://user-images.githubusercontent.com/99396485/153546895-c8d1a4cb-48f9-459b-936c-e42bd1a3d379.png)

Read more about TNS Reverse Record at https://medium.com/@terranameservice/what-is-tns-reverse-record-and-how-to-get-it-57e8086fbfb5