### PR TITLE
Change Terra's finder to Extraterrestrial

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -10,7 +10,7 @@ export const OBSERVER = "wss://observer.terra.dev"
 
 /* website */
 export const STATION = "https://station.terra.money"
-export const FINDER = "https://finder.terra.money"
+export const FINDER = "https://finder.extraterrestrial.money"
 export const EXTENSION =
   "https://chrome.google.com/webstore/detail/aiifbnbfobpmeekipheeijimdpnlpgpp"
 export const TUTORIAL =


### PR DESCRIPTION
As seen by this community poll:
https://twitter.com/TheMoonMidas/status/1474052382539587591?s=20

95% of the community requests protocols and dapps on Terra to use Extraterrestrial finder due to its full set of features.

Appreciate it!