### PR TITLE
fix: link to Terra Finder instead of Terrascope

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -10,7 +10,7 @@ export const OBSERVER = "wss://observer.terra.dev"
 
 /* website */
 export const STATION = "https://station.terra.money"
-export const FINDER = "https://terrascope.info"
+export const FINDER = "https://finder.terra.money"
 export const EXTENSION =
   "https://chrome.google.com/webstore/detail/aiifbnbfobpmeekipheeijimdpnlpgpp"
 export const TUTORIAL =


### PR DESCRIPTION
Terrascope.info was downed today and now redirect to `https://finder.terra.money/` root, but all Station link are broken as it doesn't redirect according to given path.
Their Twitter account seems deleted as well.
![image](https://user-images.githubusercontent.com/2575182/168405193-cdfbb52a-b5ff-492e-97e4-4ce2cf829012.png)
