### PR TITLE
feat(pages:gov): add show all checkbox

### DIFF
--- a/src/pages/gov/Proposals.tsx
+++ b/src/pages/gov/Proposals.tsx
@@ -1,10 +1,15 @@
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
 import { Proposal } from "@terra-money/terra.js"
 import { useGetProposalStatusItem } from "data/queries/gov"
-import { Tabs } from "components/layout"
+import { Grid, Tabs } from "components/layout"
+import { Checkbox } from "components/form"
 import ProposalsByStatus from "./ProposalsByStatus"
 
 const Proposals = () => {
+  const { t } = useTranslation()
   const getTranslation = useGetProposalStatusItem()
+  const [showAll, setShowAll] = useState(false)
 
   const tabs = [
     Proposal.Status.PROPOSAL_STATUS_VOTING_PERIOD,
@@ -14,10 +19,17 @@ const Proposals = () => {
   ].map((key) => ({
     key: Proposal.Status[key],
     tab: getTranslation(key).label,
-    children: <ProposalsByStatus status={key} />,
+    children: <ProposalsByStatus showAll={showAll} status={key} />,
   }))
 
-  return <Tabs tabs={tabs} type="card" />
+  return (
+    <Grid gap={8}>
+      <Checkbox checked={showAll} onChange={() => setShowAll(!showAll)}>
+        {t("Show all")}
+      </Checkbox>
+      <Tabs tabs={tabs} type="card" />
+    </Grid>
+  )
 }
 
 export default Proposals

--- a/src/pages/gov/ProposalsByStatus.tsx
+++ b/src/pages/gov/ProposalsByStatus.tsx
@@ -10,7 +10,13 @@ import ProposalItem from "./ProposalItem"
 import GovernanceParams from "./GovernanceParams"
 import styles from "./ProposalsByStatus.module.scss"
 
-const ProposalsByStatus = ({ status }: { status: Proposal.Status }) => {
+const ProposalsByStatus = ({
+  status,
+  showAll,
+}: {
+  status: Proposal.Status
+  showAll: boolean
+}) => {
   const { t } = useTranslation()
 
   const { data: whitelist, ...whitelistState } = useTerraAssets<number[]>(
@@ -27,7 +33,7 @@ const ProposalsByStatus = ({ status }: { status: Proposal.Status }) => {
 
     const proposals =
       status === Proposal.Status.PROPOSAL_STATUS_VOTING_PERIOD
-        ? data.filter(({ id }) => whitelist.includes(id))
+        ? data.filter(({ id }) => (showAll ? true : whitelist.includes(id)))
         : data
 
     return !proposals.length ? (


### PR DESCRIPTION
Hey there! 👋🏻 

This PR adds a checkbox so the user can decide to show all proposals or only whitelisted ones.

https://user-images.githubusercontent.com/2793951/169151484-0aebda07-85bd-44a2-a9d7-2dde055fd00c.mp4

Another option would be to call this checkbox `Display only whitelisted proposal` and turn it on by default.
I will let you decide what you prefer.

