### PR TITLE
fix: Display PROPOSAL_STATUS_FAILED as "Error during execution".

### DIFF
--- a/src/data/queries/gov.ts
+++ b/src/data/queries/gov.ts
@@ -73,7 +73,7 @@ export const useGetProposalStatusItem = () => {
         color: "danger" as Color,
       },
       [Proposal.Status.PROPOSAL_STATUS_FAILED]: {
-        label: "",
+        label: t("Error during execution"),
         color: "danger" as Color,
       },
       [Proposal.Status.PROPOSAL_STATUS_UNSPECIFIED]: {


### PR DESCRIPTION
There's currently a lot of confusion around the status of a recently passed proposal, for example: 

https://twitter.com/FatManTerra/status/1527357289874673668

In reality, the proposal simply failed. It attempted to burn more from the pool than existed. There's a good overview here: 

https://agora.terra.money/t/this-vote-was-removed/33798/7?u=octalmage

To combat the incorrect impression that the proposal was "cancelled", lets display a status message: 

<img width="733" alt="Screen Shot 2022-05-19 at 1 53 32 PM" src="https://user-images.githubusercontent.com/142006/169384701-d650b345-a951-4ebc-b5bd-f9190ec93b88.png">

