### PR TITLE
Fix Safari compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27111,9 +27111,9 @@
       "dev": true
     },
     "node_modules/xss": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.12.tgz",
-      "integrity": "sha512-8pXgz5BUUfKMrb81tmcbvLNA97ab4d6HdoBHYF5XYHa8oarc2s64hF+oqI4FhBHVBWvEM1wHGy+vqt8kZhCaNw==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.11.tgz",
+      "integrity": "sha512-EimjrjThZeK2MO7WKR9mN5ZC1CSqivSl55wvUK5EtU6acf0rzEE1pN+9ZDrFXJ82BRp3JL38pPE6S4o/rpp1zQ==",
       "dependencies": {
         "commander": "^2.20.3",
         "cssfilter": "0.0.10"
@@ -48513,9 +48513,9 @@
       "dev": true
     },
     "xss": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.12.tgz",
-      "integrity": "sha512-8pXgz5BUUfKMrb81tmcbvLNA97ab4d6HdoBHYF5XYHa8oarc2s64hF+oqI4FhBHVBWvEM1wHGy+vqt8kZhCaNw==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.11.tgz",
+      "integrity": "sha512-EimjrjThZeK2MO7WKR9mN5ZC1CSqivSl55wvUK5EtU6acf0rzEE1pN+9ZDrFXJ82BRp3JL38pPE6S4o/rpp1zQ==",
       "requires": {
         "commander": "^2.20.3",
         "cssfilter": "0.0.10"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "secp256k1": "^4.0.3",
     "semver": "^7.3.7",
     "sentence-case": "^3.0.4",
-    "xss": "^1.0.11"
+    "xss": "1.0.11"
   },
   "devDependencies": {
     "@emotion/react": "^11.9.0",


### PR DESCRIPTION
Downgrade XSS to v1.0.11 since v1.0.12 (released 2 days ago) is not compatible with Safari and other iOS browsers.

Error on Safari iOS:
<img src="https://user-images.githubusercontent.com/54709706/172056595-7c058334-c9ca-47ef-ad0d-539d5fdee87d.PNG" width="200px">

