### PR TITLE
fix: amount of 1 fails to compute gas with too few tokens

### DIFF
--- a/src/txs/stake/StakeForm.tsx
+++ b/src/txs/stake/StakeForm.tsx
@@ -104,7 +104,7 @@ const StakeForm = (props: Props) => {
 
   const estimationTxValues = useMemo(() => {
     return {
-      input: toInput(1),
+      input: toInput(2),
       // to check redelegation stacks
       source: tab === StakeAction.REDELEGATE ? source : undefined,
     }


### PR DESCRIPTION
Redelegation in classic mode fails to obtain gas with the following error,
`failed to execute message; message index: 0: too few tokens to redelegate (truncates to zero tokens): invalid request`
when attempting to redelegate from select validators.  This is reproducible with the following validators, (LUNC DAO, Orbital Command, Autism Staking, DELIGHT, PFC, and others).  
Adjusting the memo to use an input of 2 fixes this error.