### PR TITLE
Recover Tax Rate in Classic Network

### DIFF
--- a/src/data/queries/treasury.ts
+++ b/src/data/queries/treasury.ts
@@ -1,0 +1,50 @@
+import { useQueries, useQuery } from "react-query"
+import { isDenom, isDenomLuna } from "@terra.kitchen/utils"
+import { queryKey, RefetchOptions } from "../query"
+import { useLCDClient } from "./lcdClient"
+
+export const useTaxRate = (disabled = false) => {
+  const lcd = useLCDClient()
+  return useQuery(
+    [queryKey.treasury.taxRate],
+    async () => {
+      const taxRate = await lcd.treasury.taxRate()
+      return taxRate.toString()
+    },
+    { ...RefetchOptions.INFINITY, enabled: !disabled }
+  )
+}
+
+const useGetQueryTaxCap = (disabled = false) => {
+  const lcd = useLCDClient()
+
+  return (denom?: Denom) => ({
+    queryKey: [queryKey.treasury.taxCap, denom],
+    queryFn: async () => {
+      if (!denom || !getShouldTax(denom)) return "0"
+
+      try {
+        const taxCap = await lcd.treasury.taxCap(denom)
+        return taxCap.amount.toString()
+      } catch {
+        return String(1e6)
+      }
+    },
+    ...RefetchOptions.INFINITY,
+    enabled: isDenom(denom) && !disabled,
+  })
+}
+
+export const useTaxCap = (denom?: Denom) => {
+  const getQueryTaxCap = useGetQueryTaxCap()
+  return useQuery(getQueryTaxCap(denom))
+}
+
+export const useTaxCaps = (denoms: Denom[], disabled = false) => {
+  const getQueryTaxCap = useGetQueryTaxCap(disabled)
+  return useQueries(denoms.map(getQueryTaxCap))
+}
+
+/* utils */
+export const getShouldTax = (token?: Token) =>
+  isDenom(token) && !isDenomLuna(token)

--- a/src/data/queries/treasury.ts
+++ b/src/data/queries/treasury.ts
@@ -17,7 +17,7 @@ export const useTaxRate = (disabled = false) => {
 
 const useGetQueryTaxCap = (disabled = false) => {
   const lcd = useLCDClient(),
-    { config: { isClassic } } = useLCDClient();
+    { config: { isClassic } } = useLCDClient()
   return (denom?: Denom) => ({
     queryKey: [queryKey.treasury.taxCap, denom],
     queryFn: async () => {

--- a/src/data/queries/treasury.ts
+++ b/src/data/queries/treasury.ts
@@ -1,5 +1,5 @@
 import { useQueries, useQuery } from "react-query"
-import { isDenom, isDenomLuna } from "@terra.kitchen/utils"
+import { isDenom, isDenomLuna, isDenomTerra } from "@terra.kitchen/utils"
 import { queryKey, RefetchOptions } from "../query"
 import { useLCDClient } from "./lcdClient"
 
@@ -16,12 +16,12 @@ export const useTaxRate = (disabled = false) => {
 }
 
 const useGetQueryTaxCap = (disabled = false) => {
-  const lcd = useLCDClient()
-
+  const lcd = useLCDClient(),
+    { config: { isClassic } } = useLCDClient();
   return (denom?: Denom) => ({
     queryKey: [queryKey.treasury.taxCap, denom],
     queryFn: async () => {
-      if (!denom || !getShouldTax(denom)) return "0"
+      if (!denom || !getShouldTax(denom) || !!isClassic) return "0"
 
       try {
         const taxCap = await lcd.treasury.taxCap(denom)
@@ -47,4 +47,4 @@ export const useTaxCaps = (denoms: Denom[], disabled = false) => {
 
 /* utils */
 export const getShouldTax = (token?: Token) =>
-  isDenom(token) && !isDenomLuna(token)
+  isDenomLuna(token) || isDenomTerra(token)

--- a/src/data/queries/treasury.ts
+++ b/src/data/queries/treasury.ts
@@ -21,7 +21,7 @@ const useGetQueryTaxCap = (disabled = false) => {
   return (denom?: Denom) => ({
     queryKey: [queryKey.treasury.taxCap, denom],
     queryFn: async () => {
-      if (!denom || !getShouldTax(denom) || !!isClassic) return "0"
+      if (!denom || !getShouldTax(denom) || !isClassic) return "0"
 
       try {
         const taxCap = await lcd.treasury.taxCap(denom)

--- a/src/data/query.ts
+++ b/src/data/query.ts
@@ -73,6 +73,7 @@ export const queryKey = mirror({
     unbondings: "",
     pool: "",
   },
+  treasury: { taxRate: "", taxCap: "" },
   tx: { txInfo: "", create: "" },
   wasm: { contractInfo: "", contractQuery: "" },
 

--- a/src/pages/dashboard/Dashboard.module.scss
+++ b/src/pages/dashboard/Dashboard.module.scss
@@ -10,7 +10,7 @@
 
   @media (min-width: $breakpoint) and (max-width: (1400px - 0.02)) {
     grid-template-columns: repeat(2, 1fr);
-    grid-template-rows: repeat(2, 1fr);
+    grid-template-rows: auto repeat(2, 1fr);
   }
 }
 

--- a/src/pages/dashboard/Dashboard.module.scss
+++ b/src/pages/dashboard/Dashboard.module.scss
@@ -5,7 +5,7 @@
   gap: var(--grid-gap);
 
   @include desktop {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(5, 1fr);
   }
 
   @media (min-width: $breakpoint) and (max-width: (1400px - 0.02)) {

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -3,6 +3,7 @@ import classNames from "classnames/bind"
 import { useIsClassic } from "data/query"
 import { Col, Page } from "components/layout"
 import LunaPrice from "./LunaPrice"
+import TaxRate from "./TaxRate"
 import Issuance from "./Issuance"
 import CommunityPool from "./CommunityPool"
 import StakingRatio from "./StakingRatio"
@@ -20,6 +21,7 @@ const Dashboard = () => {
       <Col>
         <header className={cx(styles.header, { trisect: !isClassic })}>
           {isClassic && <LunaPrice />}
+          <TaxRate />
           <Issuance />
           <CommunityPool />
           <StakingRatio />

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -21,7 +21,7 @@ const Dashboard = () => {
       <Col>
         <header className={cx(styles.header, { trisect: !isClassic })}>
           {isClassic && <LunaPrice />}
-          <TaxRate />
+          {isClassic && <TaxRate />}
           <Issuance />
           <CommunityPool />
           <StakingRatio />

--- a/src/pages/dashboard/TaxRate.tsx
+++ b/src/pages/dashboard/TaxRate.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from "react-i18next"
+import { useTaxRate } from "data/queries/treasury"
+import { Card } from "components/layout"
+import { ReadPercent } from "components/token"
+import { TooltipIcon } from "components/display"
+import DashboardContent from "./components/DashboardContent"
+import DashboardTag from "./components/DashboardTag"
+
+const TaxRate = () => {
+  const { t } = useTranslation()
+  const { data: taxRate, ...state } = useTaxRate()
+
+  const render = () => {
+    if (!taxRate) return null
+    return (
+      <DashboardContent
+        value={<ReadPercent fixed={3}>{taxRate}</ReadPercent>}
+        footer={<DashboardTag>{t("Capped at 1 SDT")}</DashboardTag>}
+      />
+    )
+  }
+
+  return (
+    <Card
+      {...state}
+      title={
+        <TooltipIcon
+          content={t(
+            "Fees added to any Terra stablecoin transaction, excluding market swaps, to provide stability in the market."
+          )}
+        >
+          {t("Tax rate")}
+        </TooltipIcon>
+      }
+      size="small"
+    >
+      {render()}
+    </Card>
+  )
+}
+
+export default TaxRate

--- a/src/pages/dashboard/TaxRate.tsx
+++ b/src/pages/dashboard/TaxRate.tsx
@@ -1,21 +1,20 @@
 import { useTranslation } from "react-i18next"
+import { useIsClassic } from "data/query"
 import { useTaxRate } from "data/queries/treasury"
 import { Card } from "components/layout"
 import { ReadPercent } from "components/token"
 import { TooltipIcon } from "components/display"
 import DashboardContent from "./components/DashboardContent"
-import DashboardTag from "./components/DashboardTag"
 
 const TaxRate = () => {
   const { t } = useTranslation()
-  const { data: taxRate, ...state } = useTaxRate()
+  const { data: taxRate, ...state } = useTaxRate(!useIsClassic())
 
   const render = () => {
     if (!taxRate) return null
     return (
       <DashboardContent
         value={<ReadPercent fixed={3}>{taxRate}</ReadPercent>}
-        footer={<DashboardTag>{t("Capped at 1 SDT")}</DashboardTag>}
       />
     )
   }
@@ -26,7 +25,7 @@ const TaxRate = () => {
       title={
         <TooltipIcon
           content={t(
-            "Fees added to any Terra stablecoin transaction, excluding market swaps, to provide stability in the market."
+            "Burn tax and other taxes that could be enabled on the network."
           )}
         >
           {t("Tax rate")}

--- a/src/txs/Tx.tsx
+++ b/src/txs/Tx.tsx
@@ -11,8 +11,7 @@ import { head, isNil } from "ramda"
 import AccountBalanceWalletIcon from "@mui/icons-material/AccountBalanceWallet"
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline"
 import { isDenom, isDenomIBC, readDenom } from "@terra.kitchen/utils"
-import { Coin, Coins, LCDClient } from "@terra-money/terra.js"
-import { CreateTxOptions, Fee } from "@terra-money/terra.js"
+import { Coin, Coins, LCDClient, CreateTxOptions, Fee } from "@terra-money/terra.js"
 import { ConnectType, UserDenied } from "@terra-money/wallet-types"
 import { CreateTxFailed, TxFailed } from "@terra-money/wallet-types"
 import { useWallet, useConnectedWallet } from "@terra-money/use-wallet"
@@ -23,10 +22,16 @@ import { getAmount, sortCoins } from "utils/coin"
 import { getErrorMessage } from "utils/error"
 import { getLocalSetting, SettingKey } from "utils/localStorage"
 import { useCurrency } from "data/settings/Currency"
-import { queryKey, RefetchOptions, useIsClassic } from "data/query"
+import {
+  queryKey,
+  combineState,
+  RefetchOptions,
+  useIsClassic,
+} from "data/query"
 import { useAddress, useNetwork } from "data/wallet"
 import { isBroadcastingState, latestTxState } from "data/queries/tx"
 import { useBankBalance, useIsWalletEmpty } from "data/queries/bank"
+import { getShouldTax, useTaxCap, useTaxRate } from "data/queries/treasury"
 
 import { Pre } from "components/general"
 import { Flex, Grid } from "components/layout"
@@ -54,6 +59,8 @@ interface Props<TxValues> {
   initialGasDenom: CoinDenom
   estimationTxValues?: TxValues
   createTx: (values: TxValues) => CreateTxOptions | undefined
+  preventTax?: boolean
+  taxes?: Coins
   excludeGasDenom?: (denom: string) => boolean
 
   /* render */
@@ -77,7 +84,7 @@ interface RenderProps<TxValues> {
 function Tx<TxValues>(props: Props<TxValues>) {
   const { token, decimals, amount, balance } = props
   const { initialGasDenom, estimationTxValues, createTx } = props
-  const { excludeGasDenom } = props
+  const { preventTax, excludeGasDenom } = props
   const { children, onChangeMax } = props
   const { onPost, redirectAfterTx, queryKeys } = props
 
@@ -99,6 +106,12 @@ function Tx<TxValues>(props: Props<TxValues>) {
   const bankBalance = useBankBalance()
   const { gasPrices } = useTx()
 
+  /* queries: conditional */
+  const shouldTax = !preventTax && getShouldTax(token) && isClassic
+  const { data: rate = "0", ...taxRateState } = useTaxRate(!shouldTax)
+  const { data: cap = "0", ...taxCapState } = useTaxCap(token)
+  const taxState = combineState(taxRateState, taxCapState)
+
   /* simulation: estimate gas */
   const simulationTx = estimationTxValues && createTx(estimationTxValues)
   const gasAdjustment = getLocalSetting<number>(SettingKey.GasAdjustment)
@@ -108,7 +121,7 @@ function Tx<TxValues>(props: Props<TxValues>) {
     initialGasDenom,
     gasPrices,
     gasAdjustment,
-    msgs: simulationTx?.msgs.map((msg) => msg.toData()),
+    tx: simulationTx,
   }
 
   const { data: estimatedGas, ...estimatedGasState } = useQuery(
@@ -163,8 +176,8 @@ function Tx<TxValues>(props: Props<TxValues>) {
   /* max */
   const getNativeMax = () => {
     if (!balance) return
-    const gasAmount = gasFee.denom === token ? gasFee.amount : "0"
-    return calcMax({ balance, gasAmount })
+    const gasAmount = gasFee.denom === initialGasDenom ? gasFee.amount : "0"
+    return calcMax({ balance, rate, cap, gasAmount }).max
   }
 
   const max = !gasFee.amount
@@ -178,8 +191,14 @@ function Tx<TxValues>(props: Props<TxValues>) {
     if (max && isMax && onChangeMax) onChangeMax(toInput(max, decimals))
   }, [decimals, isMax, max, onChangeMax])
 
+  /* tax */
+  const taxAmount =
+    token && amount && shouldTax
+      ? calcMinimumTaxAmount(amount, { rate, cap })
+      : undefined
+
   /* (effect): Log error on console */
-  const failed = getErrorMessage(estimatedGasState.error)
+  const failed = getErrorMessage(taxState.error ?? estimatedGasState.error)
   useEffect(() => {
     if (process.env.NODE_ENV === "development" && failed) {
       console.groupCollapsed("Fee estimation failed")
@@ -197,6 +216,10 @@ function Tx<TxValues>(props: Props<TxValues>) {
   const disabled =
     passwordRequired && !password
       ? t("Enter password")
+      : taxState.isLoading
+      ? t("Loading tax data...")
+      : taxState.error
+      ? t("Failed to load tax data")
       : estimatedGasState.isLoading
       ? t("Estimating fee...")
       : estimatedGasState.error
@@ -223,7 +246,10 @@ function Tx<TxValues>(props: Props<TxValues>) {
       if (!tx) throw new Error("Tx is not defined")
 
       const gasCoins = new Coins([Coin.fromData(gasFee)])
-      const fee = new Fee(estimatedGas, gasCoins)
+      const taxCoin = token && taxAmount && new Coin(token, taxAmount)
+      const taxCoins = props.taxes ?? taxCoin
+      const feeCoins = taxCoins ? gasCoins.add(taxCoins) : gasCoins
+      const fee = new Fee(estimatedGas, feeCoins)
 
       if (isWallet.multisig(wallet)) {
         const unsignedTx = await auth.create({ ...tx, fee })
@@ -253,6 +279,7 @@ function Tx<TxValues>(props: Props<TxValues>) {
     amount &&
     new BigNumber(balance)
       .minus(amount)
+      .minus(taxAmount ?? 0)
       .minus((gasFee.denom === token && gasFee.amount) || 0)
       .toString()
 
@@ -301,6 +328,10 @@ function Tx<TxValues>(props: Props<TxValues>) {
   const renderFee = (descriptions?: Contents) => {
     if (!estimatedGas) return null
 
+    const taxes = sortCoins(props.taxes ?? new Coins(), currency).filter(
+      ({ amount }) => has(amount)
+    )
+
     return (
       <Details>
         <dl>
@@ -310,6 +341,28 @@ function Tx<TxValues>(props: Props<TxValues>) {
               <dd>{content}</dd>
             </Fragment>
           ))}
+
+          {has(taxAmount) && (
+            <>
+              <dt>{t("Tax")}</dt>
+              <dd>
+                <Read amount={taxAmount} token={token} />
+              </dd>
+            </>
+          )}
+
+          {!!taxes.length && (
+            <>
+              <dt>{t("Tax")}</dt>
+              <dd>
+                {taxes.map((coin) => (
+                  <p key={coin.denom}>
+                    <Read {...coin} />
+                  </p>
+                ))}
+              </dd>
+            </>
+          )}
 
           <dt className={styles.gas}>
             {t("Fee")}
@@ -452,19 +505,38 @@ export const getInitialGasDenom = (bankBalance: Coins) => {
 
 interface Params {
   balance: Amount
+  rate: string
+  cap: Amount
   gasAmount: Amount
 }
 
-// Receive gas and return the maximum payment amount
-export const calcMax = ({ balance, gasAmount }: Params) => {
+// Receive tax and gas information and return the maximum payment amount
+export const calcMax = ({ balance, rate, cap, gasAmount }: Params) => {
   const available = new BigNumber(balance).minus(gasAmount)
 
-  const max = BigNumber.max(new BigNumber(available), 0)
+  const tax = calcMinimumTaxAmount(available, {
+    rate: new BigNumber(rate).div(new BigNumber(1).plus(rate)),
+    cap,
+  })
+
+  const max = BigNumber.max(new BigNumber(available).minus(tax ?? 0), 0)
     .integerValue(BigNumber.ROUND_FLOOR)
     .toString()
 
-  return max
-}
+    return { max, tax }
+  }
+  
+  export const calcMinimumTaxAmount = (
+    amount: BigNumber.Value,
+    { rate, cap }: { rate: BigNumber.Value; cap: BigNumber.Value }
+  ) => {
+    const tax = BigNumber.min(
+      new BigNumber(amount).times(rate),
+      cap
+    ).integerValue(BigNumber.ROUND_FLOOR)
+  
+    return tax.gt(0) ? tax.toString() : undefined
+  }
 
 /* hooks */
 export const useTxKey = () => {

--- a/src/txs/Tx.tsx
+++ b/src/txs/Tx.tsx
@@ -121,7 +121,7 @@ function Tx<TxValues>(props: Props<TxValues>) {
     initialGasDenom,
     gasPrices,
     gasAdjustment,
-    tx: simulationTx,
+    msgs: simulationTx?.msgs.map((msg) => msg.toData()),
   }
 
   const { data: estimatedGas, ...estimatedGasState } = useQuery(
@@ -176,7 +176,7 @@ function Tx<TxValues>(props: Props<TxValues>) {
   /* max */
   const getNativeMax = () => {
     if (!balance) return
-    const gasAmount = gasFee.denom === initialGasDenom ? gasFee.amount : "0"
+    const gasAmount = gasFee.denom === token ? gasFee.amount : "0"
     return calcMax({ balance, rate, cap, gasAmount }).max
   }
 
@@ -517,8 +517,8 @@ export const calcMax = ({ balance, rate, cap, gasAmount }: Params) => {
     .integerValue(BigNumber.ROUND_FLOOR)
     .toString()
 
-    return { max, tax }
-  }
+  return { max, tax }
+}
 
   export const calcMinimumTaxAmount = (
     amount: BigNumber.Value,

--- a/src/txs/Tx.tsx
+++ b/src/txs/Tx.tsx
@@ -342,16 +342,7 @@ function Tx<TxValues>(props: Props<TxValues>) {
             </Fragment>
           ))}
 
-          {has(taxAmount) && (
-            <>
-              <dt>{t("Tax")}</dt>
-              <dd>
-                <Read amount={taxAmount} token={token} />
-              </dd>
-            </>
-          )}
-
-          {!!taxes.length && (
+          {!!isClassic && (
             <>
               <dt>{t("Tax")}</dt>
               <dd>
@@ -360,6 +351,9 @@ function Tx<TxValues>(props: Props<TxValues>) {
                     <Read {...coin} />
                   </p>
                 ))}
+                {!taxes.length && (
+                  <Read amount="0" token={token} decimals={decimals} />
+                )}
               </dd>
             </>
           )}
@@ -525,17 +519,14 @@ export const calcMax = ({ balance, rate, cap, gasAmount }: Params) => {
 
     return { max, tax }
   }
-  
+
   export const calcMinimumTaxAmount = (
     amount: BigNumber.Value,
     { rate, cap }: { rate: BigNumber.Value; cap: BigNumber.Value }
   ) => {
-    const tax = BigNumber.min(
-      new BigNumber(amount).times(rate),
-      cap
-    ).integerValue(BigNumber.ROUND_FLOOR)
-  
-    return tax.gt(0) ? tax.toString() : undefined
+    return BigNumber.min(new BigNumber(amount).times(rate), cap)
+      .integerValue(BigNumber.ROUND_FLOOR)
+      .toString()
   }
 
 /* hooks */

--- a/src/txs/send/SendForm.tsx
+++ b/src/txs/send/SendForm.tsx
@@ -14,9 +14,10 @@ import { ExternalLink } from "components/general"
 import { Auto, Card, Grid, InlineFlex } from "components/layout"
 import { Form, FormItem, FormHelp, Input, FormWarning } from "components/form"
 import AddressBookList from "../AddressBook/AddressBookList"
-import { getPlaceholder, toInput } from "../utils"
+import { getPlaceholder, toInput, calcTaxes, CoinInput } from "../utils"
 import validate from "../validate"
 import Tx, { getInitialGasDenom } from "../Tx"
+import { useTaxParams } from "../wasm/TaxParams"
 
 interface TxValues {
   recipient?: string // AccAddress | TNS
@@ -37,6 +38,7 @@ const SendForm = ({ token, decimals, balance }: Props) => {
 
   /* tx context */
   const initialGasDenom = getInitialGasDenom(bankBalance)
+  const taxParams = useTaxParams()
 
   /* form */
   const form = useForm<TxValues>({ mode: "onChange" })
@@ -98,6 +100,7 @@ const SendForm = ({ token, decimals, balance }: Props) => {
   )
 
   /* fee */
+  const taxes = calcTaxes([{ input, denom: token }] as CoinInput[], taxParams)
   const estimationTxValues = useMemo(
     () => ({ address: connectedAddress, input: toInput(1, decimals) }),
     [connectedAddress, decimals]
@@ -116,6 +119,7 @@ const SendForm = ({ token, decimals, balance }: Props) => {
     decimals,
     amount,
     balance,
+    taxes,
     initialGasDenom,
     estimationTxValues,
     createTx,

--- a/src/txs/send/SendTx.tsx
+++ b/src/txs/send/SendTx.tsx
@@ -8,6 +8,7 @@ import { useTokenItem } from "data/token"
 import { Page } from "components/layout"
 import TxContext from "../TxContext"
 import SendForm from "./SendForm"
+import TaxParamsContext from "../wasm/TaxParams"
 
 const SendTx = () => {
   const { t } = useTranslation()
@@ -29,7 +30,9 @@ const SendTx = () => {
   return (
     <Page {...state} title={t("Send {{symbol}}", { symbol })}>
       <TxContext>
-        {tokenItem && balance && <SendForm {...tokenItem} balance={balance} />}
+        <TaxParamsContext>
+          {tokenItem && balance && <SendForm {...tokenItem} balance={balance} />}
+        </TaxParamsContext>
       </TxContext>
     </Page>
   )

--- a/src/txs/swap/MultipleSwapContext.tsx
+++ b/src/txs/swap/MultipleSwapContext.tsx
@@ -1,16 +1,20 @@
 import { PropsWithChildren, useMemo } from "react"
 import { useTranslation } from "react-i18next"
+import { zipObj } from "ramda"
 import { isDenomTerraNative } from "@terra.kitchen/utils"
 import { getAmount, sortCoins } from "utils/coin"
 import createContext from "utils/createContext"
 import { useCurrency } from "data/settings/Currency"
-import { useIsClassic } from "data/query"
+import { combineState, useIsClassic } from "data/query"
 import { useBankBalance, useTerraNativeLength } from "data/queries/bank"
+import { useTaxCaps, useTaxRate } from "data/queries/treasury"
 import { readNativeDenom } from "data/token"
 import { Card } from "components/layout"
 import { Wrong } from "components/feedback"
 
 interface MultipleSwap {
+  taxRate: string
+  taxCaps: Record<Denom, Amount>
   available: TokenItemWithBalance[]
 }
 
@@ -28,6 +32,19 @@ const MultipleSwapContext = ({ children }: PropsWithChildren<{}>) => {
     .map(({ denom }) => denom)
     .filter(isDenomTerraNative)
 
+  /* treasury */
+  const { data: taxRate, ...taxRateState } = useTaxRate()
+  const taxCapsState = useTaxCaps(denoms)
+  const taxCaps = taxCapsState.every(({ isSuccess }) => isSuccess)
+    ? zipObj(
+        denoms,
+        taxCapsState.map(({ data }) => {
+          if (!data) throw new Error()
+          return data
+        })
+      )
+    : undefined
+
   const available = useMemo(() => {
     return denoms.map((denom) => {
       const balance = getAmount(bankBalance, denom)
@@ -35,20 +52,22 @@ const MultipleSwapContext = ({ children }: PropsWithChildren<{}>) => {
     })
   }, [bankBalance, denoms, isClassic])
 
+  const state = combineState(taxRateState, ...taxCapsState)
+
   const render = () => {
     if (length < 2)
       return <Wrong>{t("Multiple swap requires at least 2 coins")}</Wrong>
 
-    if (!available) return null
+    if (!(taxRate && taxCaps && available)) return null
 
     return (
-      <MultipleSwapProvider value={{ available }}>
+      <MultipleSwapProvider value={{ taxRate, taxCaps, available }}>
         {children}
       </MultipleSwapProvider>
     )
   }
 
-  return <Card>{render()}</Card>
+  return <Card {...state}>{render()}</Card>
 }
 
 export default MultipleSwapContext

--- a/src/txs/swap/SwapForm.tsx
+++ b/src/txs/swap/SwapForm.tsx
@@ -230,6 +230,7 @@ const SwapForm = () => {
     initialGasDenom,
     estimationTxValues,
     createTx,
+    preventTax: mode === SwapMode.ONCHAIN,
     onPost: () => {
       // add custom token on ask cw20
       if (!(askAsset && AccAddress.validate(askAsset) && askTokenItem)) return

--- a/src/txs/utils.ts
+++ b/src/txs/utils.ts
@@ -30,16 +30,14 @@ export const getCoins = (coins: CoinInput[], findDecimals?: FindDecimals) => {
 }
 
 export interface TaxParams {
-  taxRate: string
-  taxCaps: Record<Denom, Amount>
+  taxRate: string | undefined
+  taxCaps?: Record<Denom, Amount> | any
 }
 
 export const calcTaxes = (
   coins: CoinInput[],
   { taxRate, taxCaps }: TaxParams
 ) => {
-  if (!new BigNumber(taxRate).gt(0)) return
-
   return new Coins(
     coins
       .filter(({ input, denom }) => {
@@ -49,7 +47,7 @@ export const calcTaxes = (
       .map(({ input, denom }) => {
         const amount = toAmount(input)
         const tax = calcMinimumTaxAmount(amount, {
-          rate: taxRate,
+          rate: taxRate || "0",
           cap: taxCaps[denom],
         })
 

--- a/src/txs/wasm/ExecuteContractForm.tsx
+++ b/src/txs/wasm/ExecuteContractForm.tsx
@@ -13,9 +13,10 @@ import { useBankBalance } from "data/queries/bank"
 import { WithTokenItem } from "data/token"
 import { Form, FormGroup, FormItem } from "components/form"
 import { Input, Select, EditorInput } from "components/form"
-import { getCoins, getPlaceholder } from "../utils"
+import { calcTaxes, getCoins, getPlaceholder } from "../utils"
 import validate from "../validate"
 import Tx, { getInitialGasDenom } from "../Tx"
+import { useTaxParams } from "./TaxParams"
 import { useIBCHelper } from "../IBCHelperContext"
 
 interface TxValues {
@@ -33,6 +34,7 @@ const ExecuteContractForm = () => {
   const bankBalance = useBankBalance()
 
   /* tx context */
+  const taxParams = useTaxParams()
   const initialGasDenom = getInitialGasDenom(bankBalance)
   const defaultItem = { denom: initialGasDenom }
   const { findDecimals } = useIBCHelper()
@@ -46,6 +48,7 @@ const ExecuteContractForm = () => {
   const { register, control, watch, handleSubmit, formState } = form
   const { errors } = formState
   const values = watch()
+  const { coins } = values
   const { fields, append, remove } = useFieldArray({ control, name: "coins" })
 
   /* tx */
@@ -66,9 +69,11 @@ const ExecuteContractForm = () => {
 
   /* fee */
   const estimationTxValues = useMemo(() => values, [values])
+  const taxes = calcTaxes(coins, taxParams)
   const tx = {
     initialGasDenom,
     estimationTxValues,
+    taxes,
     createTx,
     onSuccess: { label: t("Contract"), path: "/contract" },
     queryKeys: [

--- a/src/txs/wasm/ExecuteContractTx.tsx
+++ b/src/txs/wasm/ExecuteContractTx.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next"
 import { Page, Card } from "components/layout"
 import TxContext from "../TxContext"
+import TaxParamsContext from "./TaxParams"
 import IBCHelperContext from "../IBCHelperContext"
 import ExecuteContractForm from "./ExecuteContractForm"
 
@@ -12,7 +13,9 @@ const ExecuteContractTx = () => {
       <Card>
         <TxContext>
           <IBCHelperContext>
-            <ExecuteContractForm />
+            <TaxParamsContext>
+             <ExecuteContractForm />
+            </TaxParamsContext>
           </IBCHelperContext>
         </TxContext>
       </Card>

--- a/src/txs/wasm/InstantiateContractForm.tsx
+++ b/src/txs/wasm/InstantiateContractForm.tsx
@@ -14,9 +14,10 @@ import { useBankBalance } from "data/queries/bank"
 import { WithTokenItem } from "data/token"
 import { Form, FormGroup, FormItem } from "components/form"
 import { Input, EditorInput, Select } from "components/form"
-import { getCoins, getPlaceholder } from "../utils"
+import { calcTaxes, getCoins, getPlaceholder } from "../utils"
 import validate from "../validate"
 import Tx, { getInitialGasDenom } from "../Tx"
+import { useTaxParams } from "./TaxParams"
 import { useIBCHelper } from "../IBCHelperContext"
 
 interface TxValues {
@@ -34,6 +35,7 @@ const InstantiateContractForm = () => {
   const isClassic = useIsClassic()
 
   /* tx context */
+  const taxParams = useTaxParams()
   const initialGasDenom = getInitialGasDenom(bankBalance)
   const defaultItem = { denom: initialGasDenom }
   const { findDecimals } = useIBCHelper()
@@ -47,6 +49,7 @@ const InstantiateContractForm = () => {
   const { register, control, watch, handleSubmit, formState } = form
   const { errors } = formState
   const values = watch()
+  const { coins } = values
   const { fields, append, remove } = useFieldArray({ control, name: "coins" })
 
   /* tx */
@@ -77,10 +80,12 @@ const InstantiateContractForm = () => {
 
   /* fee */
   const estimationTxValues = useMemo(() => values, [values])
+  const taxes = calcTaxes(coins, taxParams)
 
   const tx = {
     initialGasDenom,
     estimationTxValues,
+    taxes,
     createTx,
     onSuccess: { label: t("Contract"), path: "/contract" },
   }

--- a/src/txs/wasm/InstantiateContractTx.tsx
+++ b/src/txs/wasm/InstantiateContractTx.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next"
 import { Page, Card } from "components/layout"
 import TxContext from "../TxContext"
+import TaxParamsContext from "./TaxParams"
 import IBCHelperContext from "../IBCHelperContext"
 import InstantiateContractForm from "./InstantiateContractForm"
 
@@ -12,7 +13,9 @@ const InstantiateContractTx = () => {
       <Card>
         <TxContext>
           <IBCHelperContext>
-            <InstantiateContractForm />
+            <TaxParamsContext>
+              <InstantiateContractForm />
+            </TaxParamsContext>
           </IBCHelperContext>
         </TxContext>
       </Card>

--- a/src/txs/wasm/TaxParams.tsx
+++ b/src/txs/wasm/TaxParams.tsx
@@ -1,0 +1,39 @@
+import { FC } from "react"
+import { zipObj } from "ramda"
+import { Coin } from "@terra-money/terra.js"
+import createContext from "utils/createContext"
+import { combineState } from "data/query"
+import { useBankBalance } from "data/queries/bank"
+import { useTaxCaps, useTaxRate } from "data/queries/treasury"
+import { TaxParams } from "../utils"
+
+export const [useTaxParams, TaxParamsProvider] =
+  createContext<TaxParams>("useTaxParams")
+
+  interface Props {
+    children: React.ReactNode
+  }
+
+const TaxParamsContext: FC<Props> = ({ children }) => {
+  const bankBalance = useBankBalance()
+  const denoms = bankBalance.toArray().map(({ denom }: Coin) => denom) ?? []
+  const { data: taxRate, ...taxRateState } = useTaxRate()
+  const taxCapsState = useTaxCaps(denoms)
+  const state = combineState(taxRateState, ...taxCapsState)
+
+  if (!state.isSuccess || !taxRate) return null
+
+  // TODO: Review before PR
+  const taxCaps = zipObj(
+    denoms,
+    taxCapsState.map(({ data }) => data)
+  )
+
+  return (
+    <TaxParamsProvider value={{ taxRate, taxCaps }}>
+      {children}
+    </TaxParamsProvider>
+  )
+}
+
+export default TaxParamsContext

--- a/src/txs/wasm/TaxParams.tsx
+++ b/src/txs/wasm/TaxParams.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react"
+import { PropsWithChildren } from "react"
 import { zipObj } from "ramda"
 import { Coin } from "@terra-money/terra.js"
 import createContext from "utils/createContext"
@@ -10,11 +10,7 @@ import { TaxParams } from "../utils"
 export const [useTaxParams, TaxParamsProvider] =
   createContext<TaxParams>("useTaxParams")
 
-  interface Props {
-    children: React.ReactNode
-  }
-
-const TaxParamsContext: FC<Props> = ({ children }) => {
+const TaxParamsContext = ({ children }: PropsWithChildren<{}>) => {
   const bankBalance = useBankBalance()
   const denoms = bankBalance.toArray().map(({ denom }: Coin) => denom) ?? []
   const { data: taxRate } = useTaxRate(!useIsClassic()) || "0"

--- a/src/txs/wasm/TaxParams.tsx
+++ b/src/txs/wasm/TaxParams.tsx
@@ -2,7 +2,7 @@ import { FC } from "react"
 import { zipObj } from "ramda"
 import { Coin } from "@terra-money/terra.js"
 import createContext from "utils/createContext"
-import { combineState } from "data/query"
+import { useIsClassic } from "data/query"
 import { useBankBalance } from "data/queries/bank"
 import { useTaxCaps, useTaxRate } from "data/queries/treasury"
 import { TaxParams } from "../utils"
@@ -17,16 +17,14 @@ export const [useTaxParams, TaxParamsProvider] =
 const TaxParamsContext: FC<Props> = ({ children }) => {
   const bankBalance = useBankBalance()
   const denoms = bankBalance.toArray().map(({ denom }: Coin) => denom) ?? []
-  const { data: taxRate, ...taxRateState } = useTaxRate()
+  const { data: taxRate } = useTaxRate(!useIsClassic()) || "0"
   const taxCapsState = useTaxCaps(denoms)
-  const state = combineState(taxRateState, ...taxCapsState)
 
-  if (!state.isSuccess || !taxRate) return null
-
-  // TODO: Review before PR
   const taxCaps = zipObj(
     denoms,
-    taxCapsState.map(({ data }) => data)
+    taxCapsState.map(({ data }) => {
+      return data
+    })
   )
 
   return (


### PR DESCRIPTION
These changes aim to implement the burn tax as voted on Classic governance proposal 3568 and currently undergoing vote in proposal 4661 in all Station views and gas fee calculations on classic network only. Tax rates will only be displayed on classic network once the burn tax is activated, and it will not affect any other TXs on different networks.