### PR TITLE
Recover Tax Rate in Classic Network (#101)

### DIFF
--- a/src/data/queries/treasury.ts
+++ b/src/data/queries/treasury.ts
@@ -1,0 +1,50 @@
+import { useQueries, useQuery } from "react-query"
+import { isDenom, isDenomLuna, isDenomTerra } from "@terra.kitchen/utils"
+import { queryKey, RefetchOptions } from "../query"
+import { useLCDClient } from "./lcdClient"
+
+export const useTaxRate = (disabled = false) => {
+  const lcd = useLCDClient()
+  return useQuery(
+    [queryKey.treasury.taxRate],
+    async () => {
+      const taxRate = await lcd.treasury.taxRate()
+      return taxRate.toString()
+    },
+    { ...RefetchOptions.INFINITY, enabled: !disabled }
+  )
+}
+
+const useGetQueryTaxCap = (disabled = false) => {
+  const lcd = useLCDClient(),
+    { config: { isClassic } } = useLCDClient()
+  return (denom?: Denom) => ({
+    queryKey: [queryKey.treasury.taxCap, denom],
+    queryFn: async () => {
+      if (!denom || !getShouldTax(denom) || !isClassic) return "0"
+
+      try {
+        const taxCap = await lcd.treasury.taxCap(denom)
+        return taxCap.amount.toString()
+      } catch {
+        return String(1e6)
+      }
+    },
+    ...RefetchOptions.INFINITY,
+    enabled: isDenom(denom) && !disabled,
+  })
+}
+
+export const useTaxCap = (denom?: Denom) => {
+  const getQueryTaxCap = useGetQueryTaxCap()
+  return useQuery(getQueryTaxCap(denom))
+}
+
+export const useTaxCaps = (denoms: Denom[], disabled = false) => {
+  const getQueryTaxCap = useGetQueryTaxCap(disabled)
+  return useQueries(denoms.map(getQueryTaxCap))
+}
+
+/* utils */
+export const getShouldTax = (token?: Token) =>
+  isDenomLuna(token) || isDenomTerra(token)

--- a/src/data/query.ts
+++ b/src/data/query.ts
@@ -73,6 +73,7 @@ export const queryKey = mirror({
     unbondings: "",
     pool: "",
   },
+  treasury: { taxRate: "", taxCap: "" },
   tx: { txInfo: "", create: "" },
   wasm: { contractInfo: "", contractQuery: "" },
 

--- a/src/pages/dashboard/Dashboard.module.scss
+++ b/src/pages/dashboard/Dashboard.module.scss
@@ -5,12 +5,12 @@
   gap: var(--grid-gap);
 
   @include desktop {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(5, 1fr);
   }
 
   @media (min-width: $breakpoint) and (max-width: (1400px - 0.02)) {
     grid-template-columns: repeat(2, 1fr);
-    grid-template-rows: repeat(2, 1fr);
+    grid-template-rows: auto repeat(2, 1fr);
   }
 }
 

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -3,6 +3,7 @@ import classNames from "classnames/bind"
 import { useIsClassic } from "data/query"
 import { Col, Page } from "components/layout"
 import LunaPrice from "./LunaPrice"
+import TaxRate from "./TaxRate"
 import Issuance from "./Issuance"
 import CommunityPool from "./CommunityPool"
 import StakingRatio from "./StakingRatio"
@@ -21,6 +22,7 @@ const Dashboard = () => {
       <Col>
         <header className={cx(styles.header, { trisect: !isClassic })}>
           {isClassic && <LunaPrice />}
+          {isClassic && <TaxRate />}
           <Issuance />
           <CommunityPool />
           <StakingRatio />

--- a/src/pages/dashboard/TaxRate.tsx
+++ b/src/pages/dashboard/TaxRate.tsx
@@ -1,0 +1,41 @@
+import { useTranslation } from "react-i18next"
+import { useIsClassic } from "data/query"
+import { useTaxRate } from "data/queries/treasury"
+import { Card } from "components/layout"
+import { ReadPercent } from "components/token"
+import { TooltipIcon } from "components/display"
+import DashboardContent from "./components/DashboardContent"
+
+const TaxRate = () => {
+  const { t } = useTranslation()
+  const { data: taxRate, ...state } = useTaxRate(!useIsClassic())
+
+  const render = () => {
+    if (!taxRate) return null
+    return (
+      <DashboardContent
+        value={<ReadPercent fixed={3}>{taxRate}</ReadPercent>}
+      />
+    )
+  }
+
+  return (
+    <Card
+      {...state}
+      title={
+        <TooltipIcon
+          content={t(
+            "Burn tax and other taxes that could be enabled on the network."
+          )}
+        >
+          {t("Tax rate")}
+        </TooltipIcon>
+      }
+      size="small"
+    >
+      {render()}
+    </Card>
+  )
+}
+
+export default TaxRate

--- a/src/txs/send/SendForm.tsx
+++ b/src/txs/send/SendForm.tsx
@@ -15,9 +15,10 @@ import { ExternalLink } from "components/general"
 import { Auto, Card, Grid, InlineFlex } from "components/layout"
 import { Form, FormItem, FormHelp, Input, FormWarning } from "components/form"
 import AddressBookList from "../AddressBook/AddressBookList"
-import { getPlaceholder, toInput } from "../utils"
+import { getPlaceholder, toInput, calcTaxes, CoinInput } from "../utils"
 import validate from "../validate"
 import Tx, { getInitialGasDenom } from "../Tx"
+import { useTaxParams } from "../wasm/TaxParams"
 import is from "auth/scripts/is"
 import { SendPayload } from "types/components"
 
@@ -41,6 +42,7 @@ const SendForm = ({ token, decimals, balance }: Props) => {
 
   /* tx context */
   const initialGasDenom = getInitialGasDenom(bankBalance)
+  const taxParams = useTaxParams()
 
   /* form */
   const form = useForm<TxValues>({ mode: "onChange" })
@@ -119,6 +121,7 @@ const SendForm = ({ token, decimals, balance }: Props) => {
   )
 
   /* fee */
+  const taxes = calcTaxes([{ input, denom: token }] as CoinInput[], taxParams)
   const estimationTxValues = useMemo(
     () => ({ address: connectedAddress, input: toInput(1, decimals) }),
     [connectedAddress, decimals]
@@ -137,6 +140,7 @@ const SendForm = ({ token, decimals, balance }: Props) => {
     decimals,
     amount,
     balance,
+    taxes,
     initialGasDenom,
     estimationTxValues,
     createTx,

--- a/src/txs/send/SendTx.tsx
+++ b/src/txs/send/SendTx.tsx
@@ -8,6 +8,7 @@ import { useTokenItem } from "data/token"
 import { Page } from "components/layout"
 import TxContext from "../TxContext"
 import SendForm from "./SendForm"
+import TaxParamsContext from "../wasm/TaxParams"
 
 const SendTx = () => {
   const { t } = useTranslation()
@@ -29,7 +30,9 @@ const SendTx = () => {
   return (
     <Page {...state} title={t("Send {{symbol}}", { symbol })}>
       <TxContext>
-        {tokenItem && balance && <SendForm {...tokenItem} balance={balance} />}
+        <TaxParamsContext>
+          {tokenItem && balance && <SendForm {...tokenItem} balance={balance} />}
+        </TaxParamsContext>
       </TxContext>
     </Page>
   )

--- a/src/txs/swap/MultipleSwapContext.tsx
+++ b/src/txs/swap/MultipleSwapContext.tsx
@@ -1,16 +1,20 @@
 import { PropsWithChildren, useMemo } from "react"
 import { useTranslation } from "react-i18next"
+import { zipObj } from "ramda"
 import { isDenomTerraNative } from "@terra.kitchen/utils"
 import { getAmount, sortCoins } from "utils/coin"
 import createContext from "utils/createContext"
 import { useCurrency } from "data/settings/Currency"
-import { useIsClassic } from "data/query"
+import { combineState, useIsClassic } from "data/query"
 import { useBankBalance, useTerraNativeLength } from "data/queries/bank"
+import { useTaxCaps, useTaxRate } from "data/queries/treasury"
 import { readNativeDenom } from "data/token"
 import { Card } from "components/layout"
 import { Wrong } from "components/feedback"
 
 interface MultipleSwap {
+  taxRate: string
+  taxCaps: Record<Denom, Amount>
   available: TokenItemWithBalance[]
 }
 
@@ -28,6 +32,19 @@ const MultipleSwapContext = ({ children }: PropsWithChildren<{}>) => {
     .map(({ denom }) => denom)
     .filter(isDenomTerraNative)
 
+  /* treasury */
+  const { data: taxRate, ...taxRateState } = useTaxRate()
+  const taxCapsState = useTaxCaps(denoms)
+  const taxCaps = taxCapsState.every(({ isSuccess }) => isSuccess)
+    ? zipObj(
+        denoms,
+        taxCapsState.map(({ data }) => {
+          if (!data) throw new Error()
+          return data
+        })
+      )
+    : undefined
+
   const available = useMemo(() => {
     return denoms.map((denom) => {
       const balance = getAmount(bankBalance, denom)
@@ -35,20 +52,22 @@ const MultipleSwapContext = ({ children }: PropsWithChildren<{}>) => {
     })
   }, [bankBalance, denoms, isClassic])
 
+  const state = combineState(taxRateState, ...taxCapsState)
+
   const render = () => {
     if (length < 2)
       return <Wrong>{t("Multiple swap requires at least 2 coins")}</Wrong>
 
-    if (!available) return null
+    if (!(taxRate && taxCaps && available)) return null
 
     return (
-      <MultipleSwapProvider value={{ available }}>
+      <MultipleSwapProvider value={{ taxRate, taxCaps, available }}>
         {children}
       </MultipleSwapProvider>
     )
   }
 
-  return <Card>{render()}</Card>
+  return <Card {...state}>{render()}</Card>
 }
 
 export default MultipleSwapContext

--- a/src/txs/swap/SwapForm.tsx
+++ b/src/txs/swap/SwapForm.tsx
@@ -231,6 +231,7 @@ const SwapForm = () => {
     initialGasDenom,
     estimationTxValues,
     createTx,
+    preventTax: mode === SwapMode.ONCHAIN,
     onPost: () => {
       // add custom token on ask cw20
       if (!(askAsset && AccAddress.validate(askAsset) && askTokenItem)) return

--- a/src/txs/swap/SwapMultipleForm.tsx
+++ b/src/txs/swap/SwapMultipleForm.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "react-query"
 import { useForm } from "react-hook-form"
 import BigNumber from "bignumber.js"
 import { flatten, fromPairs } from "ramda"
+import { Coin, Coins } from "@terra-money/terra.js"
 import is from "auth/scripts/is"
 
 /* helpers */
@@ -37,7 +38,7 @@ interface TxValues {
 
 // available > simulatable > simulated > selectable > offers
 // available: all assets
-// simulatable: non-askAsset, balance.
+// simulatable: non-askAsset, balance exists except tax.
 // selectable: simulated result value exists
 // offers: selected by the user
 const SwapMultipleForm = () => {
@@ -49,7 +50,7 @@ const SwapMultipleForm = () => {
   const utils = useSwapUtils()
   const { getSwapMode, getSimulateFunction, getMsgsFunction } = utils
   const { activeDenoms } = useSwap()
-  const { available } = useMultipleSwap()
+  const { taxRate, taxCaps, available } = useMultipleSwap()
   const initialGasDenom = "uluna"
 
   /* options: askAsset */
@@ -77,12 +78,14 @@ const SwapMultipleForm = () => {
         .map((item) => {
           const { token: offerAsset, balance } = item
           const mode = getSwapMode({ offerAsset, askAsset })
-          if (mode === SwapMode.ONCHAIN) return { ...item, max: balance }
-          const max = calcMax({ balance, gasAmount: "0" })
-          return { ...item, max }
+          if (mode === SwapMode.ONCHAIN)
+            return { ...item, max: balance, tax: "0" }
+          const cap = taxCaps[offerAsset]
+          const max = calcMax({ balance, rate: taxRate, cap, gasAmount: "0" })
+          return { ...item, ...max }
         })
         .filter(({ token, max }) => token !== askAsset && has(max)),
-    [askAsset, available, getSwapMode]
+    [askAsset, available, getSwapMode, taxCaps, taxRate]
   )
 
   /* simulate */
@@ -90,16 +93,16 @@ const SwapMultipleForm = () => {
     ["simulate.swap.multiple", simulatable, askAsset],
     async () => {
       const simulated = await Promise.allSettled(
-        simulatable.map(async ({ token: offerAsset, max: amount }) => {
+        simulatable.map(async ({ token: offerAsset, max: amount, tax }) => {
           const mode = getSwapMode({ offerAsset, askAsset })
 
           try {
             const params = { amount, offerAsset, askAsset }
             const { value } = await getSimulateFunction(mode)(params)
-            return { offerAsset, mode, amount, value }
+            return { offerAsset, mode, amount, tax, value }
           } catch (error) {
             // errors because too small amount is simulated
-            return { offerAsset, mode, amount, value: "0" }
+            return { offerAsset, mode, amount, tax, value: "0" }
           }
         })
       )
@@ -149,6 +152,15 @@ const SwapMultipleForm = () => {
   /* fee */
   const estimationTxValues = useMemo(() => ({ askAsset }), [askAsset])
 
+  const taxes = new Coins(
+    offers
+      .filter(({ tax }) => has(tax))
+      .map(({ offerAsset, tax }) => {
+        if (!tax) throw new Error()
+        return new Coin(offerAsset, tax)
+      })
+  )
+
   const excludeGasDenom = useCallback(
     (denom: string) => !!state[denom],
     [state]
@@ -158,6 +170,7 @@ const SwapMultipleForm = () => {
     initialGasDenom,
     estimationTxValues,
     createTx,
+    taxes,
     excludeGasDenom,
     onSuccess: { label: t("Wallet"), path: "/wallet" },
   }

--- a/src/txs/utils.ts
+++ b/src/txs/utils.ts
@@ -2,6 +2,8 @@ import BigNumber from "bignumber.js"
 import { readAmount, toAmount } from "@terra.kitchen/utils"
 import { Coin, Coins } from "@terra-money/terra.js"
 import { has } from "utils/num"
+import { getShouldTax } from "data/queries/treasury"
+import { calcMinimumTaxAmount } from "./Tx"
 import { FindDecimals } from "./IBCHelperContext"
 
 export const getPlaceholder = (decimals = 6) => "0.".padEnd(decimals + 2, "0")
@@ -24,5 +26,33 @@ export const getCoins = (coins: CoinInput[], findDecimals?: FindDecimals) => {
       })
       .filter(({ amount }) => has(amount))
       .map(({ amount, denom }) => new Coin(denom, amount))
+  )
+}
+
+export interface TaxParams {
+  taxRate: string | undefined
+  taxCaps?: Record<Denom, Amount> | any
+}
+
+export const calcTaxes = (
+  coins: CoinInput[],
+  { taxRate, taxCaps }: TaxParams
+) => {
+  return new Coins(
+    coins
+      .filter(({ input, denom }) => {
+        const amount = toAmount(input)
+        return has(amount) && getShouldTax(denom)
+      })
+      .map(({ input, denom }) => {
+        const amount = toAmount(input)
+        const tax = calcMinimumTaxAmount(amount, {
+          rate: taxRate || "0",
+          cap: taxCaps[denom],
+        })
+
+        if (!tax) throw new Error()
+        return new Coin(denom, tax)
+      })
   )
 }

--- a/src/txs/wasm/ExecuteContractForm.tsx
+++ b/src/txs/wasm/ExecuteContractForm.tsx
@@ -13,9 +13,10 @@ import { useBankBalance } from "data/queries/bank"
 import { WithTokenItem } from "data/token"
 import { Form, FormGroup, FormItem } from "components/form"
 import { Input, Select, EditorInput } from "components/form"
-import { getCoins, getPlaceholder } from "../utils"
+import { calcTaxes, getCoins, getPlaceholder } from "../utils"
 import validate from "../validate"
 import Tx, { getInitialGasDenom } from "../Tx"
+import { useTaxParams } from "./TaxParams"
 import { useIBCHelper } from "../IBCHelperContext"
 
 interface TxValues {
@@ -33,6 +34,7 @@ const ExecuteContractForm = () => {
   const bankBalance = useBankBalance()
 
   /* tx context */
+  const taxParams = useTaxParams()
   const initialGasDenom = getInitialGasDenom(bankBalance)
   const defaultItem = { denom: initialGasDenom }
   const { findDecimals } = useIBCHelper()
@@ -54,6 +56,7 @@ const ExecuteContractForm = () => {
   } = form
   const { errors } = formState
   const values = watch()
+  const { coins } = values
   const { fields, append, remove } = useFieldArray({ control, name: "coins" })
 
   /* tx */
@@ -74,9 +77,11 @@ const ExecuteContractForm = () => {
 
   /* fee */
   const estimationTxValues = useMemo(() => values, [values])
+  const taxes = calcTaxes(coins, taxParams)
   const tx = {
     initialGasDenom,
     estimationTxValues,
+    taxes,
     createTx,
     onSuccess: { label: t("Contract"), path: "/contract" },
     queryKeys: [

--- a/src/txs/wasm/ExecuteContractTx.tsx
+++ b/src/txs/wasm/ExecuteContractTx.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next"
 import { Page, Card } from "components/layout"
 import TxContext from "../TxContext"
+import TaxParamsContext from "./TaxParams"
 import IBCHelperContext from "../IBCHelperContext"
 import ExecuteContractForm from "./ExecuteContractForm"
 
@@ -12,7 +13,9 @@ const ExecuteContractTx = () => {
       <Card>
         <TxContext>
           <IBCHelperContext>
-            <ExecuteContractForm />
+            <TaxParamsContext>
+             <ExecuteContractForm />
+            </TaxParamsContext>
           </IBCHelperContext>
         </TxContext>
       </Card>

--- a/src/txs/wasm/InstantiateContractForm.tsx
+++ b/src/txs/wasm/InstantiateContractForm.tsx
@@ -14,9 +14,10 @@ import { useBankBalance } from "data/queries/bank"
 import { WithTokenItem } from "data/token"
 import { Form, FormGroup, FormItem } from "components/form"
 import { Input, EditorInput, Select } from "components/form"
-import { getCoins, getPlaceholder } from "../utils"
+import { calcTaxes, getCoins, getPlaceholder } from "../utils"
 import validate from "../validate"
 import Tx, { getInitialGasDenom } from "../Tx"
+import { useTaxParams } from "./TaxParams"
 import { useIBCHelper } from "../IBCHelperContext"
 
 interface TxValues {
@@ -34,6 +35,7 @@ const InstantiateContractForm = () => {
   const isClassic = useIsClassic()
 
   /* tx context */
+  const taxParams = useTaxParams()
   const initialGasDenom = getInitialGasDenom(bankBalance)
   const defaultItem = { denom: initialGasDenom }
   const { findDecimals } = useIBCHelper()
@@ -55,6 +57,7 @@ const InstantiateContractForm = () => {
   } = form
   const { errors } = formState
   const values = watch()
+  const { coins } = values
   const { fields, append, remove } = useFieldArray({ control, name: "coins" })
 
   /* tx */
@@ -85,10 +88,12 @@ const InstantiateContractForm = () => {
 
   /* fee */
   const estimationTxValues = useMemo(() => values, [values])
+  const taxes = calcTaxes(coins, taxParams)
 
   const tx = {
     initialGasDenom,
     estimationTxValues,
+    taxes,
     createTx,
     onSuccess: { label: t("Contract"), path: "/contract" },
   }

--- a/src/txs/wasm/InstantiateContractTx.tsx
+++ b/src/txs/wasm/InstantiateContractTx.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next"
 import { Page, Card } from "components/layout"
 import TxContext from "../TxContext"
+import TaxParamsContext from "./TaxParams"
 import IBCHelperContext from "../IBCHelperContext"
 import InstantiateContractForm from "./InstantiateContractForm"
 
@@ -12,7 +13,9 @@ const InstantiateContractTx = () => {
       <Card>
         <TxContext>
           <IBCHelperContext>
-            <InstantiateContractForm />
+            <TaxParamsContext>
+              <InstantiateContractForm />
+            </TaxParamsContext>
           </IBCHelperContext>
         </TxContext>
       </Card>

--- a/src/txs/wasm/TaxParams.tsx
+++ b/src/txs/wasm/TaxParams.tsx
@@ -1,0 +1,33 @@
+import { PropsWithChildren } from "react"
+import { zipObj } from "ramda"
+import { Coin } from "@terra-money/terra.js"
+import createContext from "utils/createContext"
+import { useIsClassic } from "data/query"
+import { useBankBalance } from "data/queries/bank"
+import { useTaxCaps, useTaxRate } from "data/queries/treasury"
+import { TaxParams } from "../utils"
+
+export const [useTaxParams, TaxParamsProvider] =
+  createContext<TaxParams>("useTaxParams")
+
+const TaxParamsContext = ({ children }: PropsWithChildren<{}>) => {
+  const bankBalance = useBankBalance()
+  const denoms = bankBalance.toArray().map(({ denom }: Coin) => denom) ?? []
+  const { data: taxRate } = useTaxRate(!useIsClassic()) || "0"
+  const taxCapsState = useTaxCaps(denoms)
+
+  const taxCaps = zipObj(
+    denoms,
+    taxCapsState.map(({ data }) => {
+      return data
+    })
+  )
+
+  return (
+    <TaxParamsProvider value={{ taxRate, taxCaps }}>
+      {children}
+    </TaxParamsProvider>
+  )
+}
+
+export default TaxParamsContext


### PR DESCRIPTION
These changes aim to implement the burn tax as voted on Classic governance proposal 3568 and currently undergoing vote in proposal 4661 in all Station views and gas fee calculations on classic network only. Tax rates will only be displayed on classic network once the burn tax is activated, and it will not affect any other TXs on different networks.