### PR TITLE
Fixed gas and tax calculation errors on classic network

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -27,6 +27,7 @@ export const LEDGER_TRANSPORT_TIMEOUT = 120000
 
 /* tx */
 export const DEFAULT_GAS_ADJUSTMENT = 2
+export const CLASSIC_DEFAULT_GAS_ADJUSTMENT = 3
 
 /* swap */
 export const TERRASWAP_COMMISSION_RATE = 0.003

--- a/src/data/queries/treasury.ts
+++ b/src/data/queries/treasury.ts
@@ -49,5 +49,5 @@ export const isNativeToken = (token?: Token) =>
   isDenomLuna(token) || isDenomTerra(token)
 
 /* utils */
-export const useShouldTax = (token?: Token, isClassic?: boolean) =>
+export const getShouldTax = (token?: Token, isClassic?: boolean) =>
   isClassic && isNativeToken(token)

--- a/src/data/queries/treasury.ts
+++ b/src/data/queries/treasury.ts
@@ -9,7 +9,7 @@ export const useTaxRate = (disabled = false) => {
     [queryKey.treasury.taxRate],
     async () => {
       const taxRate = await lcd.treasury.taxRate()
-      return taxRate.toString()
+      return taxRate.toString() || "0"
     },
     { ...RefetchOptions.INFINITY, enabled: !disabled }
   )
@@ -21,7 +21,7 @@ const useGetQueryTaxCap = (disabled = false) => {
   return (denom?: Denom) => ({
     queryKey: [queryKey.treasury.taxCap, denom],
     queryFn: async () => {
-      if (!denom || !getShouldTax(denom) || !isClassic) return "0"
+      if (!denom || !isClassic || !isNativeToken(denom)) return "0"
 
       try {
         const taxCap = await lcd.treasury.taxCap(denom)
@@ -45,6 +45,9 @@ export const useTaxCaps = (denoms: Denom[], disabled = false) => {
   return useQueries(denoms.map(getQueryTaxCap))
 }
 
-/* utils */
-export const getShouldTax = (token?: Token) =>
+export const isNativeToken = (token?: Token) =>
   isDenomLuna(token) || isDenomTerra(token)
+
+/* utils */
+export const useShouldTax = (token?: Token, isClassic?: boolean) =>
+  isClassic && isNativeToken(token)

--- a/src/txs/Tx.tsx
+++ b/src/txs/Tx.tsx
@@ -120,7 +120,8 @@ function Tx<TxValues>(props: Props<TxValues>) {
 
   /* simulation: estimate gas */
   const simulationTx = estimationTxValues && createTx(estimationTxValues)
-  const gasAdjustment = getLocalSetting<number>(SettingKey.GasAdjustment)
+  const gasAdjustmentSetting = isClassic ? SettingKey.ClassicGasAdjustment : SettingKey.GasAdjustment
+  const gasAdjustment = getLocalSetting<number>(gasAdjustmentSetting)
   const key = {
     address,
     network,

--- a/src/txs/Tx.tsx
+++ b/src/txs/Tx.tsx
@@ -28,7 +28,7 @@ import { queryKey, combineState, useIsClassic } from "data/query"
 import { useAddress, useNetwork } from "data/wallet"
 import { isBroadcastingState, latestTxState } from "data/queries/tx"
 import { useBankBalance, useIsWalletEmpty } from "data/queries/bank"
-import { useShouldTax, useTaxCap, useTaxRate } from "data/queries/treasury"
+import { getShouldTax, useTaxCap, useTaxRate } from "data/queries/treasury"
 
 import { Pre } from "components/general"
 import { Flex, Grid } from "components/layout"
@@ -113,7 +113,7 @@ function Tx<TxValues>(props: Props<TxValues>) {
         isClassic
       )
     : undefined
-  const shouldTax = useShouldTax(token, isClassic) && taxRequired
+  const shouldTax = getShouldTax(token, isClassic) && taxRequired
   const { data: rate = "0", ...taxRateState } = useTaxRate(!shouldTax)
   const { data: cap = "0", ...taxCapState } = useTaxCap(token)
   const taxState = combineState(taxRateState, taxCapState)

--- a/src/txs/TxContext.tsx
+++ b/src/txs/TxContext.tsx
@@ -5,6 +5,7 @@ import { GasPrices, useGasPrices } from "data/Terra/TerraAPI"
 import { Card } from "components/layout"
 import { ErrorBoundary, Wrong } from "components/feedback"
 import { useTxKey } from "./Tx"
+import TaxParamsContext from "./wasm/TaxParams"
 
 export const [useTx, TxProvider] = createContext<{ gasPrices: GasPrices }>(
   "useTx"
@@ -26,9 +27,11 @@ const TxContext = ({ children }: PropsWithChildren<{}>) => {
   if (!gasPrices) return null
 
   return (
-    <TxProvider value={{ gasPrices }} key={txKey}>
-      <ErrorBoundary fallback={fallback}>{children}</ErrorBoundary>
-    </TxProvider>
+    <TaxParamsContext>
+      <TxProvider value={{ gasPrices }} key={txKey}>
+        <ErrorBoundary fallback={fallback}>{children}</ErrorBoundary>
+      </TxProvider>
+    </TaxParamsContext>
   )
 }
 

--- a/src/txs/send/SendForm.tsx
+++ b/src/txs/send/SendForm.tsx
@@ -14,10 +14,9 @@ import { ExternalLink } from "components/general"
 import { Auto, Card, Grid, InlineFlex } from "components/layout"
 import { Form, FormItem, FormHelp, Input, FormWarning } from "components/form"
 import AddressBookList from "../AddressBook/AddressBookList"
-import { getPlaceholder, toInput, calcTaxes, CoinInput } from "../utils"
+import { getPlaceholder, toInput, CoinInput } from "../utils"
 import validate from "../validate"
 import Tx, { getInitialGasDenom } from "../Tx"
-import { useTaxParams } from "../wasm/TaxParams"
 
 interface TxValues {
   recipient?: string // AccAddress | TNS
@@ -38,7 +37,6 @@ const SendForm = ({ token, decimals, balance }: Props) => {
 
   /* tx context */
   const initialGasDenom = getInitialGasDenom(bankBalance)
-  const taxParams = useTaxParams()
 
   /* form */
   const form = useForm<TxValues>({ mode: "onChange" })
@@ -100,7 +98,7 @@ const SendForm = ({ token, decimals, balance }: Props) => {
   )
 
   /* fee */
-  const taxes = calcTaxes([{ input, denom: token }] as CoinInput[], taxParams)
+  const coins = [{ input, denom: token }] as CoinInput[]
   const estimationTxValues = useMemo(
     () => ({ address: connectedAddress, input: toInput(1, decimals) }),
     [connectedAddress, decimals]
@@ -118,14 +116,15 @@ const SendForm = ({ token, decimals, balance }: Props) => {
     token,
     decimals,
     amount,
+    coins,
     balance,
-    taxes,
     initialGasDenom,
     estimationTxValues,
     createTx,
     disabled,
     onChangeMax,
     onSuccess: { label: t("Wallet"), path: "/wallet" },
+    preventTax: false,
     queryKeys: AccAddress.validate(token)
       ? [[queryKey.wasm.contractQuery, token, { balance: connectedAddress }]]
       : undefined,

--- a/src/txs/send/SendForm.tsx
+++ b/src/txs/send/SendForm.tsx
@@ -98,7 +98,8 @@ const SendForm = ({ token, decimals, balance }: Props) => {
   )
 
   /* fee */
-  const coins = [{ input, denom: token }] as CoinInput[]
+  const taxRequired = true
+  const coins = [{ input, denom: token, taxRequired }] as CoinInput[]
   const estimationTxValues = useMemo(
     () => ({ address: connectedAddress, input: toInput(1, decimals) }),
     [connectedAddress, decimals]
@@ -124,7 +125,7 @@ const SendForm = ({ token, decimals, balance }: Props) => {
     disabled,
     onChangeMax,
     onSuccess: { label: t("Wallet"), path: "/wallet" },
-    preventTax: false,
+    taxRequired,
     queryKeys: AccAddress.validate(token)
       ? [[queryKey.wasm.contractQuery, token, { balance: connectedAddress }]]
       : undefined,

--- a/src/txs/send/SendForm.tsx
+++ b/src/txs/send/SendForm.tsx
@@ -98,8 +98,7 @@ const SendForm = ({ token, decimals, balance }: Props) => {
   )
 
   /* fee */
-  const taxRequired = true
-  const coins = [{ input, denom: token, taxRequired }] as CoinInput[]
+  const coins = [{ input, denom: token, taxRequired: true }] as CoinInput[]
   const estimationTxValues = useMemo(
     () => ({ address: connectedAddress, input: toInput(1, decimals) }),
     [connectedAddress, decimals]
@@ -125,7 +124,7 @@ const SendForm = ({ token, decimals, balance }: Props) => {
     disabled,
     onChangeMax,
     onSuccess: { label: t("Wallet"), path: "/wallet" },
-    taxRequired,
+    taxRequired: true,
     queryKeys: AccAddress.validate(token)
       ? [[queryKey.wasm.contractQuery, token, { balance: connectedAddress }]]
       : undefined,

--- a/src/txs/send/SendTx.tsx
+++ b/src/txs/send/SendTx.tsx
@@ -8,7 +8,6 @@ import { useTokenItem } from "data/token"
 import { Page } from "components/layout"
 import TxContext from "../TxContext"
 import SendForm from "./SendForm"
-import TaxParamsContext from "../wasm/TaxParams"
 
 const SendTx = () => {
   const { t } = useTranslation()
@@ -30,9 +29,7 @@ const SendTx = () => {
   return (
     <Page {...state} title={t("Send {{symbol}}", { symbol })}>
       <TxContext>
-        <TaxParamsContext>
-          {tokenItem && balance && <SendForm {...tokenItem} balance={balance} />}
-        </TaxParamsContext>
+        {tokenItem && balance && <SendForm {...tokenItem} balance={balance} />}
       </TxContext>
     </Page>
   )

--- a/src/txs/swap/SwapForm.tsx
+++ b/src/txs/swap/SwapForm.tsx
@@ -22,7 +22,7 @@ import { Checkbox, RadioButton } from "components/form"
 import { Read } from "components/token"
 
 /* tx modules */
-import { getPlaceholder, toInput } from "../utils"
+import { getPlaceholder, toInput, CoinInput } from "../utils"
 import validate from "../validate"
 import Tx, { getInitialGasDenom } from "../Tx"
 
@@ -221,11 +221,13 @@ const SwapForm = () => {
   )
 
   const token = offerAsset
+  const coins = [{ input, denom: token }] as CoinInput[]
   const decimals = offerDecimals
   const tx = {
     token,
     decimals,
     amount,
+    coins,
     balance,
     initialGasDenom,
     estimationTxValues,

--- a/src/txs/swap/SwapForm.tsx
+++ b/src/txs/swap/SwapForm.tsx
@@ -220,8 +220,9 @@ const SwapForm = () => {
     }
   )
 
+  const taxRequired = mode !== SwapMode.ONCHAIN
   const token = offerAsset
-  const coins = [{ input, denom: token }] as CoinInput[]
+  const coins = [{ input, denom: token, taxRequired }] as CoinInput[]
   const decimals = offerDecimals
   const tx = {
     token,
@@ -232,7 +233,7 @@ const SwapForm = () => {
     initialGasDenom,
     estimationTxValues,
     createTx,
-    preventTax: mode === SwapMode.ONCHAIN,
+    taxRequired,
     onPost: () => {
       // add custom token on ask cw20
       if (!(askAsset && AccAddress.validate(askAsset) && askTokenItem)) return

--- a/src/txs/swap/SwapMultipleForm.tsx
+++ b/src/txs/swap/SwapMultipleForm.tsx
@@ -4,7 +4,6 @@ import { useQuery } from "react-query"
 import { useForm } from "react-hook-form"
 import BigNumber from "bignumber.js"
 import { flatten, fromPairs } from "ramda"
-import { Coin, Coins } from "@terra-money/terra.js"
 
 /* helpers */
 import { has } from "utils/num"
@@ -30,6 +29,7 @@ import useSwapUtils, { SwapMode } from "./useSwapUtils"
 import { useSwap } from "./SwapContext"
 import { useMultipleSwap } from "./MultipleSwapContext"
 import styles from "./SwapMultipleForm.module.scss"
+import { CoinInput, toInput } from "txs/utils"
 
 interface TxValues {
   askAsset: CoinDenom
@@ -151,15 +151,13 @@ const SwapMultipleForm = () => {
   /* fee */
   const estimationTxValues = useMemo(() => ({ askAsset }), [askAsset])
 
-  const taxes = new Coins(
-    offers
-      .filter(({ tax }) => has(tax))
-      .map(({ offerAsset, tax }) => {
-        if (!tax) throw new Error()
-        return new Coin(offerAsset, tax)
-      })
-  )
-
+  const coins = offers.map(({ offerAsset, amount, tax }) => {
+    return {
+      input: toInput(amount),
+      denom: offerAsset,
+      preventTax: (isClassic && !tax) ?? true,
+    } as CoinInput
+  })
   const excludeGasDenom = useCallback(
     (denom: string) => !!state[denom],
     [state]
@@ -169,9 +167,10 @@ const SwapMultipleForm = () => {
     initialGasDenom,
     estimationTxValues,
     createTx,
-    taxes,
+    coins,
     excludeGasDenom,
     onSuccess: { label: t("Wallet"), path: "/wallet" },
+    preventTax: false,
   }
 
   const disabled = isSimulating ? t("Simulating...") : false

--- a/src/txs/swap/SwapMultipleForm.tsx
+++ b/src/txs/swap/SwapMultipleForm.tsx
@@ -155,7 +155,7 @@ const SwapMultipleForm = () => {
     return {
       input: toInput(amount),
       denom: offerAsset,
-      preventTax: (isClassic && !tax) ?? true,
+      taxRequired: isClassic && !!parseFloat(tax),
     } as CoinInput
   })
   const excludeGasDenom = useCallback(
@@ -168,9 +168,9 @@ const SwapMultipleForm = () => {
     estimationTxValues,
     createTx,
     coins,
+    taxRequired: true,
     excludeGasDenom,
     onSuccess: { label: t("Wallet"), path: "/wallet" },
-    preventTax: false,
   }
 
   const disabled = isSimulating ? t("Simulating...") : false

--- a/src/txs/swap/TFMSwapForm.tsx
+++ b/src/txs/swap/TFMSwapForm.tsx
@@ -24,7 +24,7 @@ import { Checkbox } from "components/form"
 import { Read } from "components/token"
 
 /* tx modules */
-import { getPlaceholder, toInput, CoinInput } from "../utils"
+import { getPlaceholder, toInput } from "../utils"
 import validate from "../validate"
 import Tx, { getInitialGasDenom } from "../Tx"
 
@@ -199,18 +199,15 @@ const TFMSwapForm = () => {
   )
 
   const token = offerAsset
-  const coins = [{ input, denom: token }] as CoinInput[]
   const decimals = offerDecimals
   const tx = {
     token,
     decimals,
     amount,
-    coins,
     balance,
     initialGasDenom,
     estimationTxValues,
     createTx,
-    preventTax: false,
     queryKeys: [offerAsset, askAsset]
       .filter((asset) => asset && AccAddress.validate(asset))
       .map((token) => [

--- a/src/txs/swap/TFMSwapForm.tsx
+++ b/src/txs/swap/TFMSwapForm.tsx
@@ -24,7 +24,7 @@ import { Checkbox } from "components/form"
 import { Read } from "components/token"
 
 /* tx modules */
-import { getPlaceholder, toInput } from "../utils"
+import { getPlaceholder, toInput, CoinInput } from "../utils"
 import validate from "../validate"
 import Tx, { getInitialGasDenom } from "../Tx"
 
@@ -199,15 +199,18 @@ const TFMSwapForm = () => {
   )
 
   const token = offerAsset
+  const coins = [{ input, denom: token }] as CoinInput[]
   const decimals = offerDecimals
   const tx = {
     token,
     decimals,
     amount,
+    coins,
     balance,
     initialGasDenom,
     estimationTxValues,
     createTx,
+    preventTax: false,
     queryKeys: [offerAsset, askAsset]
       .filter((asset) => asset && AccAddress.validate(asset))
       .map((token) => [

--- a/src/txs/utils.ts
+++ b/src/txs/utils.ts
@@ -31,13 +31,13 @@ export const getCoins = (coins: CoinInput[], findDecimals?: FindDecimals) => {
 }
 
 export interface TaxParams {
-  taxRate: string | any
-  taxCaps?: Record<Denom, Amount> | any
+  taxRate?: string
+  taxCaps?: Record<Denom, Amount>
 }
 
 export const calcTaxes = (
   coins: CoinInput[],
-  { taxRate, taxCaps }: TaxParams,
+  { taxRate = "0", taxCaps = {} }: TaxParams,
   isClassic: boolean
 ) => {
   return new Coins(

--- a/src/txs/utils.ts
+++ b/src/txs/utils.ts
@@ -2,7 +2,7 @@ import BigNumber from "bignumber.js"
 import { readAmount, toAmount } from "@terra.kitchen/utils"
 import { Coin, Coins } from "@terra-money/terra.js"
 import { has } from "utils/num"
-import { useShouldTax } from "data/queries/treasury"
+import { getShouldTax } from "data/queries/treasury"
 import { calcMinimumTaxAmount } from "./Tx"
 import { FindDecimals } from "./IBCHelperContext"
 
@@ -31,7 +31,7 @@ export const getCoins = (coins: CoinInput[], findDecimals?: FindDecimals) => {
 }
 
 export interface TaxParams {
-  taxRate: string | undefined
+  taxRate: string | any
   taxCaps?: Record<Denom, Amount> | any
 }
 
@@ -44,12 +44,12 @@ export const calcTaxes = (
     coins
       .filter(({ input, denom, taxRequired }) => {
         const amount = toAmount(input)
-        return useShouldTax(denom, isClassic) && has(amount) && taxRequired
+        return getShouldTax(denom, isClassic) && has(amount) && taxRequired
       })
       .map(({ input, denom, taxRequired }) => {
         const amount = toAmount(input)
         const tax = calcMinimumTaxAmount(amount, {
-          rate: (taxRequired && taxRate) || "0",
+          rate: taxRequired ? taxRate : "0",
           cap: taxCaps[denom],
         })
 

--- a/src/txs/utils.ts
+++ b/src/txs/utils.ts
@@ -15,6 +15,7 @@ export const toInput = (amount: BigNumber.Value, decimals = 6) =>
 export interface CoinInput {
   input?: number
   denom: CoinDenom
+  preventTax?: boolean
 }
 
 export const getCoins = (coins: CoinInput[], findDecimals?: FindDecimals) => {
@@ -40,14 +41,14 @@ export const calcTaxes = (
 ) => {
   return new Coins(
     coins
-      .filter(({ input, denom }) => {
+      .filter(({ input, denom, preventTax }) => {
         const amount = toAmount(input)
-        return has(amount) && getShouldTax(denom)
+        return has(amount) && !preventTax && getShouldTax(denom)
       })
-      .map(({ input, denom }) => {
+      .map(({ input, denom, preventTax }) => {
         const amount = toAmount(input)
         const tax = calcMinimumTaxAmount(amount, {
-          rate: taxRate || "0",
+          rate: preventTax ? "0" : taxRate || "0",
           cap: taxCaps[denom],
         })
 

--- a/src/txs/wasm/ExecuteContractForm.tsx
+++ b/src/txs/wasm/ExecuteContractForm.tsx
@@ -73,7 +73,7 @@ const ExecuteContractForm = () => {
     coins,
     createTx,
     onSuccess: { label: t("Contract"), path: "/contract" },
-    preventTax: false,
+    taxRequired: true,
     queryKeys: [
       [queryKey.wasm.contractQuery, contract, { tokens: { owner: address } }],
     ],

--- a/src/txs/wasm/ExecuteContractForm.tsx
+++ b/src/txs/wasm/ExecuteContractForm.tsx
@@ -13,10 +13,9 @@ import { useBankBalance } from "data/queries/bank"
 import { WithTokenItem } from "data/token"
 import { Form, FormGroup, FormItem } from "components/form"
 import { Input, Select, EditorInput } from "components/form"
-import { calcTaxes, getCoins, getPlaceholder } from "../utils"
+import { getCoins, getPlaceholder } from "../utils"
 import validate from "../validate"
 import Tx, { getInitialGasDenom } from "../Tx"
-import { useTaxParams } from "./TaxParams"
 import { useIBCHelper } from "../IBCHelperContext"
 
 interface TxValues {
@@ -34,7 +33,6 @@ const ExecuteContractForm = () => {
   const bankBalance = useBankBalance()
 
   /* tx context */
-  const taxParams = useTaxParams()
   const initialGasDenom = getInitialGasDenom(bankBalance)
   const defaultItem = { denom: initialGasDenom }
   const { findDecimals } = useIBCHelper()
@@ -69,13 +67,13 @@ const ExecuteContractForm = () => {
 
   /* fee */
   const estimationTxValues = useMemo(() => values, [values])
-  const taxes = calcTaxes(coins, taxParams)
   const tx = {
     initialGasDenom,
     estimationTxValues,
-    taxes,
+    coins,
     createTx,
     onSuccess: { label: t("Contract"), path: "/contract" },
+    preventTax: false,
     queryKeys: [
       [queryKey.wasm.contractQuery, contract, { tokens: { owner: address } }],
     ],

--- a/src/txs/wasm/ExecuteContractTx.tsx
+++ b/src/txs/wasm/ExecuteContractTx.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next"
 import { Page, Card } from "components/layout"
 import TxContext from "../TxContext"
-import TaxParamsContext from "./TaxParams"
 import IBCHelperContext from "../IBCHelperContext"
 import ExecuteContractForm from "./ExecuteContractForm"
 
@@ -13,9 +12,7 @@ const ExecuteContractTx = () => {
       <Card>
         <TxContext>
           <IBCHelperContext>
-            <TaxParamsContext>
-             <ExecuteContractForm />
-            </TaxParamsContext>
+            <ExecuteContractForm />
           </IBCHelperContext>
         </TxContext>
       </Card>

--- a/src/txs/wasm/InstantiateContractForm.tsx
+++ b/src/txs/wasm/InstantiateContractForm.tsx
@@ -14,10 +14,9 @@ import { useBankBalance } from "data/queries/bank"
 import { WithTokenItem } from "data/token"
 import { Form, FormGroup, FormItem } from "components/form"
 import { Input, EditorInput, Select } from "components/form"
-import { calcTaxes, getCoins, getPlaceholder } from "../utils"
+import { getCoins, getPlaceholder } from "../utils"
 import validate from "../validate"
 import Tx, { getInitialGasDenom } from "../Tx"
-import { useTaxParams } from "./TaxParams"
 import { useIBCHelper } from "../IBCHelperContext"
 
 interface TxValues {
@@ -35,7 +34,6 @@ const InstantiateContractForm = () => {
   const isClassic = useIsClassic()
 
   /* tx context */
-  const taxParams = useTaxParams()
   const initialGasDenom = getInitialGasDenom(bankBalance)
   const defaultItem = { denom: initialGasDenom }
   const { findDecimals } = useIBCHelper()
@@ -80,14 +78,14 @@ const InstantiateContractForm = () => {
 
   /* fee */
   const estimationTxValues = useMemo(() => values, [values])
-  const taxes = calcTaxes(coins, taxParams)
 
   const tx = {
     initialGasDenom,
     estimationTxValues,
-    taxes,
+    coins,
     createTx,
     onSuccess: { label: t("Contract"), path: "/contract" },
+    preventTax: false,
   }
 
   const length = fields.length

--- a/src/txs/wasm/InstantiateContractForm.tsx
+++ b/src/txs/wasm/InstantiateContractForm.tsx
@@ -85,7 +85,7 @@ const InstantiateContractForm = () => {
     coins,
     createTx,
     onSuccess: { label: t("Contract"), path: "/contract" },
-    preventTax: false,
+    taxRequired: true,
   }
 
   const length = fields.length

--- a/src/txs/wasm/InstantiateContractTx.tsx
+++ b/src/txs/wasm/InstantiateContractTx.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next"
 import { Page, Card } from "components/layout"
 import TxContext from "../TxContext"
-import TaxParamsContext from "./TaxParams"
 import IBCHelperContext from "../IBCHelperContext"
 import InstantiateContractForm from "./InstantiateContractForm"
 
@@ -13,9 +12,7 @@ const InstantiateContractTx = () => {
       <Card>
         <TxContext>
           <IBCHelperContext>
-            <TaxParamsContext>
-              <InstantiateContractForm />
-            </TaxParamsContext>
+            <InstantiateContractForm />
           </IBCHelperContext>
         </TxContext>
       </Card>

--- a/src/txs/wasm/TaxParams.tsx
+++ b/src/txs/wasm/TaxParams.tsx
@@ -24,7 +24,7 @@ const TaxParamsContext = ({ children }: PropsWithChildren<{}>) => {
   )
 
   return (
-    <TaxParamsProvider value={{ taxRate, taxCaps }}>
+    <TaxParamsProvider value={{ taxRate, taxCaps } as TaxParams}>
       {children}
     </TaxParamsProvider>
   )

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_GAS_ADJUSTMENT } from "config/constants"
+import { DEFAULT_GAS_ADJUSTMENT, CLASSIC_DEFAULT_GAS_ADJUSTMENT } from "config/constants"
 import themes from "styles/themes/themes"
 
 export enum SettingKey {
@@ -6,6 +6,7 @@ export enum SettingKey {
   Currency = "Currency",
   CustomNetworks = "CustomNetworks",
   GasAdjustment = "GasAdjustment", // Tx
+  ClassicGasAdjustment = "ClassicGasAdjustment",
   AddressBook = "AddressBook", // Send
   CustomTokens = "CustomTokens", // Wallet
   MinimumValue = "MinimumValue", // Wallet (UST value to show on the list)
@@ -25,6 +26,7 @@ export const DefaultSettings = {
   [SettingKey.Currency]: "uusd",
   [SettingKey.CustomNetworks]: [] as CustomNetwork[],
   [SettingKey.GasAdjustment]: DEFAULT_GAS_ADJUSTMENT,
+  [SettingKey.ClassicGasAdjustment]: CLASSIC_DEFAULT_GAS_ADJUSTMENT,
   [SettingKey.AddressBook]: [] as AddressBook[],
   [SettingKey.CustomTokens]: DefaultCustomTokens as CustomTokens,
   [SettingKey.MinimumValue]: 0,


### PR DESCRIPTION
This PR addresses issues reported to us about the tax being applied to the wrong transaction types.

It also takes care of the current gas estimations issues in the LCD that don't account for the burn tax properly. Although we will be patching that in our next core v.23 release, we are proposing to increase the gas adjustment multiplier for classic only.