### PR TITLE
fix: docs tutorial link

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -14,7 +14,7 @@ export const FINDER = "https://terrascope.info"
 export const EXTENSION =
   "https://chrome.google.com/webstore/detail/aiifbnbfobpmeekipheeijimdpnlpgpp"
 export const TUTORIAL =
-  "https://docs.terra.money/Tutorials/Get-started/Terra-Station-desktop.html"
+  "https://docs.terra.money/learn/terra-station/Download/terra-station-desktop.html"
 
 /* website: stake */
 export const TERRA_VALIDATORS =


### PR DESCRIPTION
Updating docs tutorial hyperlink in the bottom left-hand corner to link to the Terra Station Desktop guide on docs.terra.money