### PR TITLE
add whitelist for terra and terra classic

### DIFF
--- a/src/pages/gov/ProposalsByStatus.tsx
+++ b/src/pages/gov/ProposalsByStatus.tsx
@@ -20,7 +20,7 @@ const ProposalsByStatus = ({ status }: { status: Proposal.Status }) => {
   const toggle = () => setShowAll((state) => !state)
 
   const { data: whitelist, ...whitelistState } = useTerraAssets<number[]>(
-    "/station/proposals.json"
+    isClassic() ? "/station/proposal-classic" :"/station/proposal-classic" 
   )
 
   const { data, ...proposalState } = useProposals(status)
@@ -69,7 +69,7 @@ const ProposalsByStatus = ({ status }: { status: Proposal.Status }) => {
   return (
     <Fetching {...state}>
       <Col>
-        {isClassic && status === Proposal.Status.PROPOSAL_STATUS_VOTING_PERIOD && (
+        {whitelistState && status === Proposal.Status.PROPOSAL_STATUS_VOTING_PERIOD && (
           <section>
             <Toggle checked={showAll} onChange={toggle}>
               {t("Show all")}


### PR DESCRIPTION
Accompanying this PR a new file in assets: https://github.com/terra-money/assets/pull/605

The goal of this PR is to implement a whitelist for both Terra (phoenix) and Terra Classic (Columbus)
I am not a station developer, and expect this will not be merged.
It's purpose is to provide a clear communication of intent, and to learn from something new. :)