### PR TITLE
Add whitelist for mainnet

### DIFF
--- a/src/data/query.ts
+++ b/src/data/query.ts
@@ -6,11 +6,6 @@ export const useIsClassic = () => {
   return networkName === "columbus-5" // TODO
 }
 
-export const useIsMainnet = () => {
-  const networkName = useChainID()
-  return networkName === "phoenix-1" // TODO
-}
-
 /* refetch */
 export const RefetchOptions = {
   DEFAULT: /* onMount, onFocus */ {},

--- a/src/data/query.ts
+++ b/src/data/query.ts
@@ -1,14 +1,14 @@
-import { useChainID } from 'auth/hooks/useNetwork'
-import { LAZY_LIMIT } from 'config/constants'
+import { useChainID } from "auth/hooks/useNetwork"
+import { LAZY_LIMIT } from "config/constants"
 
 export const useIsClassic = () => {
   const networkName = useChainID()
-  return networkName === 'columbus-5' // TODO
+  return networkName === "columbus-5" // TODO
 }
 
 export const useIsMainnet = () => {
   const networkName = useChainID()
-  return networkName === 'phoenix-1' // TODO
+  return networkName === "phoenix-1" // TODO
 }
 
 /* refetch */
@@ -19,7 +19,7 @@ export const RefetchOptions = {
 
 /* params */
 export const Pagination = {
-  'pagination.limit': String(LAZY_LIMIT),
+  "pagination.limit": String(LAZY_LIMIT),
 }
 
 /* helpers */
@@ -34,53 +34,53 @@ export const combineState = (...results: QueryState[]) => ({
 /* queryKey */
 const mirror = <T>(obj: T, parentKey?: string): T =>
   Object.entries(obj).reduce((acc, [key, value]) => {
-    const next = value ? mirror(value, key) : [parentKey, key].filter(Boolean).join('.')
+    const next = value ? mirror(value, key) : [parentKey, key].filter(Boolean).join(".")
 
     return { ...acc, [key]: next }
   }, {} as T)
 
 export const queryKey = mirror({
   /* assets */
-  TerraAssets: '',
-  TerraAPI: '',
-  History: '',
+  TerraAssets: "",
+  TerraAPI: "",
+  History: "",
 
   /* lcd */
-  auth: { accountInfo: '' },
-  bank: { balance: '', balances: '', supply: '' },
+  auth: { accountInfo: "" },
+  bank: { balance: "", balances: "", supply: "" },
   distribution: {
-    rewards: '',
-    communityPool: '',
-    validatorCommission: '',
-    withdrawAddress: '',
+    rewards: "",
+    communityPool: "",
+    validatorCommission: "",
+    withdrawAddress: "",
   },
   gov: {
-    votingParams: '',
-    depositParams: '',
-    tallyParams: '',
-    proposals: '',
-    proposal: '',
-    deposits: '',
-    votes: '',
-    tally: '',
+    votingParams: "",
+    depositParams: "",
+    tallyParams: "",
+    proposals: "",
+    proposal: "",
+    deposits: "",
+    votes: "",
+    tally: "",
   },
-  ibc: { denomTrace: '' },
-  market: { params: '' },
-  oracle: { activeDenoms: '', exchangeRates: '', params: '' },
-  tendermint: { nodeInfo: '' },
+  ibc: { denomTrace: "" },
+  market: { params: "" },
+  oracle: { activeDenoms: "", exchangeRates: "", params: "" },
+  tendermint: { nodeInfo: "" },
   staking: {
-    validators: '',
-    validator: '',
-    delegations: '',
-    delegation: '',
-    unbondings: '',
-    pool: '',
+    validators: "",
+    validator: "",
+    delegations: "",
+    delegation: "",
+    unbondings: "",
+    pool: "",
   },
-  treasury: { taxRate: '', taxCap: '' },
-  tx: { txInfo: '', create: '' },
-  wasm: { contractInfo: '', contractQuery: '' },
+  treasury: { taxRate: "", taxCap: "" },
+  tx: { txInfo: "", create: "" },
+  wasm: { contractInfo: "", contractQuery: "" },
 
   /* external */
-  Anchor: { TotalDeposit: '', APY: '', MarketEpochState: '' },
-  TNS: '',
+  Anchor: { TotalDeposit: "", APY: "", MarketEpochState: "" },
+  TNS: "",
 })

--- a/src/data/query.ts
+++ b/src/data/query.ts
@@ -29,7 +29,9 @@ export const combineState = (...results: QueryState[]) => ({
 /* queryKey */
 const mirror = <T>(obj: T, parentKey?: string): T =>
   Object.entries(obj).reduce((acc, [key, value]) => {
-    const next = value ? mirror(value, key) : [parentKey, key].filter(Boolean).join(".")
+    const next = value 
+      ? mirror(value, key) 
+      : [parentKey, key].filter(Boolean).join(".")
 
     return { ...acc, [key]: next }
   }, {} as T)

--- a/src/data/query.ts
+++ b/src/data/query.ts
@@ -1,9 +1,14 @@
-import { useChainID } from "auth/hooks/useNetwork"
-import { LAZY_LIMIT } from "config/constants"
+import { useChainID } from 'auth/hooks/useNetwork'
+import { LAZY_LIMIT } from 'config/constants'
 
 export const useIsClassic = () => {
   const networkName = useChainID()
-  return networkName === "columbus-5" // TODO
+  return networkName === 'columbus-5' // TODO
+}
+
+export const useIsMainnet = () => {
+  const networkName = useChainID()
+  return networkName === 'phoenix-1' // TODO
 }
 
 /* refetch */
@@ -14,7 +19,7 @@ export const RefetchOptions = {
 
 /* params */
 export const Pagination = {
-  "pagination.limit": String(LAZY_LIMIT),
+  'pagination.limit': String(LAZY_LIMIT),
 }
 
 /* helpers */
@@ -29,55 +34,53 @@ export const combineState = (...results: QueryState[]) => ({
 /* queryKey */
 const mirror = <T>(obj: T, parentKey?: string): T =>
   Object.entries(obj).reduce((acc, [key, value]) => {
-    const next = value
-      ? mirror(value, key)
-      : [parentKey, key].filter(Boolean).join(".")
+    const next = value ? mirror(value, key) : [parentKey, key].filter(Boolean).join('.')
 
     return { ...acc, [key]: next }
   }, {} as T)
 
 export const queryKey = mirror({
   /* assets */
-  TerraAssets: "",
-  TerraAPI: "",
-  History: "",
+  TerraAssets: '',
+  TerraAPI: '',
+  History: '',
 
   /* lcd */
-  auth: { accountInfo: "" },
-  bank: { balance: "", balances: "", supply: "" },
+  auth: { accountInfo: '' },
+  bank: { balance: '', balances: '', supply: '' },
   distribution: {
-    rewards: "",
-    communityPool: "",
-    validatorCommission: "",
-    withdrawAddress: "",
+    rewards: '',
+    communityPool: '',
+    validatorCommission: '',
+    withdrawAddress: '',
   },
   gov: {
-    votingParams: "",
-    depositParams: "",
-    tallyParams: "",
-    proposals: "",
-    proposal: "",
-    deposits: "",
-    votes: "",
-    tally: "",
+    votingParams: '',
+    depositParams: '',
+    tallyParams: '',
+    proposals: '',
+    proposal: '',
+    deposits: '',
+    votes: '',
+    tally: '',
   },
-  ibc: { denomTrace: "" },
-  market: { params: "" },
-  oracle: { activeDenoms: "", exchangeRates: "", params: "" },
-  tendermint: { nodeInfo: "" },
+  ibc: { denomTrace: '' },
+  market: { params: '' },
+  oracle: { activeDenoms: '', exchangeRates: '', params: '' },
+  tendermint: { nodeInfo: '' },
   staking: {
-    validators: "",
-    validator: "",
-    delegations: "",
-    delegation: "",
-    unbondings: "",
-    pool: "",
+    validators: '',
+    validator: '',
+    delegations: '',
+    delegation: '',
+    unbondings: '',
+    pool: '',
   },
-  treasury: { taxRate: "", taxCap: "" },
-  tx: { txInfo: "", create: "" },
-  wasm: { contractInfo: "", contractQuery: "" },
+  treasury: { taxRate: '', taxCap: '' },
+  tx: { txInfo: '', create: '' },
+  wasm: { contractInfo: '', contractQuery: '' },
 
   /* external */
-  Anchor: { TotalDeposit: "", APY: "", MarketEpochState: "" },
-  TNS: "",
+  Anchor: { TotalDeposit: '', APY: '', MarketEpochState: '' },
+  TNS: '',
 })

--- a/src/pages/gov/ProposalsByStatus.tsx
+++ b/src/pages/gov/ProposalsByStatus.tsx
@@ -1,16 +1,16 @@
-import { useState } from 'react'
-import { useTranslation } from 'react-i18next'
-import { reverse } from 'ramda'
-import { Proposal } from '@terra-money/terra.js'
-import { combineState, useIsClassic, useIsMainnet } from 'data/query'
-import { useProposals, useProposalStatusItem } from 'data/queries/gov'
-import { useTerraAssets } from 'data/Terra/TerraAssets'
-import { Col, Card } from 'components/layout'
-import { Fetching, Empty } from 'components/feedback'
-import { Toggle } from 'components/form'
-import ProposalItem from './ProposalItem'
-import GovernanceParams from './GovernanceParams'
-import styles from './ProposalsByStatus.module.scss'
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+import { reverse } from "ramda"
+import { Proposal } from "@terra-money/terra.js"
+import { combineState, useIsClassic, useIsMainnet } from "data/query"
+import { useProposals, useProposalStatusItem } from "data/queries/gov"
+import { useTerraAssets } from "data/Terra/TerraAssets"
+import { Col, Card } from "components/layout"
+import { Fetching, Empty } from "components/feedback"
+import { Toggle } from "components/form"
+import ProposalItem from "./ProposalItem"
+import GovernanceParams from "./GovernanceParams"
+import styles from "./ProposalsByStatus.module.scss"
 
 const ProposalsByStatus = ({ status }: { status: Proposal.Status }) => {
   const { t } = useTranslation()
@@ -23,7 +23,7 @@ const ProposalsByStatus = ({ status }: { status: Proposal.Status }) => {
   const { data: whitelist, ...whitelistState } = useTerraAssets<{
     classic: number[]
     mainnet: number[]
-  }>('/station/proposals.json')
+  }>("/station/proposals.json")
 
   const { data, ...proposalState } = useProposals(status)
   const { label } = useProposalStatusItem(status)
@@ -35,14 +35,14 @@ const ProposalsByStatus = ({ status }: { status: Proposal.Status }) => {
 
     const proposals =
       status === Proposal.Status.PROPOSAL_STATUS_VOTING_PERIOD && !showAll
-        ? data.filter(({ id }) => (whitelist[isClassic ? 'classic' : 'mainnet'] || []).includes(id))
+        ? data.filter(({ id }) => (whitelist[isClassic ? "classic" : "mainnet"] || []).includes(id))
         : data
 
     return !proposals.length ? (
       <>
         <Card>
           <Empty>
-            {t('No proposals in {{label}} period', {
+            {t("No proposals in {{label}} period", {
               label: label.toLowerCase(),
             })}
           </Empty>
@@ -70,7 +70,7 @@ const ProposalsByStatus = ({ status }: { status: Proposal.Status }) => {
         {(isClassic || isMainnet) && status === Proposal.Status.PROPOSAL_STATUS_VOTING_PERIOD && (
           <section>
             <Toggle checked={showAll} onChange={toggle}>
-              {t('Show all')}
+              {t("Show all")}
             </Toggle>
           </section>
         )}

--- a/src/pages/gov/ProposalsByStatus.tsx
+++ b/src/pages/gov/ProposalsByStatus.tsx
@@ -20,7 +20,7 @@ const ProposalsByStatus = ({ status }: { status: Proposal.Status }) => {
   const toggle = () => setShowAll((state) => !state)
 
   const { data: whitelist, ...whitelistState } = useTerraAssets<number[]>(
-    "/station/proposals.json"
+    isClassic() ? "/station/proposal-classic" :"/station/proposal-classic" 
   )
 
   const { data, ...proposalState } = useProposals(status)
@@ -69,7 +69,7 @@ const ProposalsByStatus = ({ status }: { status: Proposal.Status }) => {
   return (
     <Fetching {...state}>
       <Col>
-        {isClassic && status === Proposal.Status.PROPOSAL_STATUS_VOTING_PERIOD && (
+        {whitelistState && status === Proposal.Status.PROPOSAL_STATUS_VOTING_PERIOD && (
           <section>
             <Toggle checked={showAll} onChange={toggle}>
               {t("Show all")}

--- a/src/pages/gov/ProposalsByStatus.tsx
+++ b/src/pages/gov/ProposalsByStatus.tsx
@@ -17,10 +17,10 @@ const ProposalsByStatus = ({ status }: { status: Proposal.Status }) => {
   const { t } = useTranslation()
   const networkName = useNetworkName()
 
-  const { data: whitelist, ...whitelistState } = useTerraAssets<{ [key: string]: number[] }> ("/station/proposals.json")
+  const { data: whitelistData, ...whitelistState } = useTerraAssets<{ [key: string]: number[] }> ("/station/proposals.json")
+  const whitelist = whitelistData?.[networkName]
 
-  const whitelistExists = whitelist && whitelist[networkName]
-  const [showAll, setShowAll] = useState(!whitelistExists)
+  const [showAll, setShowAll] = useState(!!whitelist)
   const toggle = () => setShowAll((state) => !state)
 
 
@@ -30,11 +30,11 @@ const ProposalsByStatus = ({ status }: { status: Proposal.Status }) => {
   const state = combineState(whitelistState, proposalState)
 
   const render = () => {
-    if (!(data && whitelist)) return null
+    if (!(data && whitelistData)) return null
 
     const proposals =
       status === Proposal.Status.PROPOSAL_STATUS_VOTING_PERIOD && !showAll
-        ? data.filter(({ id }) => (whitelist[networkName] || []).includes(id))
+        ? data.filter(({ id }) => whitelist?.includes(id))
         : data
 
     return !proposals.length ? (
@@ -66,7 +66,7 @@ const ProposalsByStatus = ({ status }: { status: Proposal.Status }) => {
   return (
     <Fetching {...state}>
       <Col>
-        {whitelistExists && status === Proposal.Status.PROPOSAL_STATUS_VOTING_PERIOD && (
+        {!!whitelist && status === Proposal.Status.PROPOSAL_STATUS_VOTING_PERIOD && (
           <section>
             <Toggle checked={showAll} onChange={toggle}>
               {t("Show all")}


### PR DESCRIPTION
Implemented some fixes from PR #118 by @Jared-TFL:
- fix error that prevent compiling
- hadle testnet
- use same `proposals.json` file with this format:
```js
{
  mainnet: number[]
  classic: number[]
}
```

It will need another PR on terra-money/asset to update proposals.json.