### PR TITLE
Add modal popup for external (non-Terra) links contained in governance proposal descriptions

### DIFF
--- a/src/components/general/External.tsx
+++ b/src/components/general/External.tsx
@@ -1,13 +1,19 @@
-import { ForwardedRef, forwardRef, HTMLProps, ReactNode } from "react"
+import { ForwardedRef, forwardRef, HTMLProps, ReactNode, useState } from "react"
 import CallMadeIcon from "@mui/icons-material/CallMade"
+import CloseIcon from "@mui/icons-material/Close"
 import styles from "./Internal.module.scss"
+import { Modal } from "components/feedback"
+import { Submit } from "components/form"
 
 interface ExternalLinkProps extends HTMLProps<HTMLAnchorElement> {
   icon?: boolean
 }
 
 export const ExternalLink = forwardRef(
-  ({ icon, children, href, ...attrs }: ExternalLinkProps, ref: ForwardedRef<HTMLAnchorElement>) => {
+  (
+    { icon, children, href, ...attrs }: ExternalLinkProps,
+    ref: ForwardedRef<HTMLAnchorElement>
+  ) => {
     if (!validateLink(href)) return null
 
     return (
@@ -23,7 +29,7 @@ export const ExternalLink = forwardRef(
         {icon && <CallMadeIcon fontSize="inherit" />}
       </a>
     )
-  },
+  }
 )
 
 interface ExternalIconLinkProps extends HTMLProps<HTMLAnchorElement> {
@@ -33,7 +39,7 @@ interface ExternalIconLinkProps extends HTMLProps<HTMLAnchorElement> {
 export const ExternalIconLink = forwardRef(
   (
     { icon, children, href, ...attrs }: ExternalIconLinkProps,
-    ref: ForwardedRef<HTMLAnchorElement>,
+    ref: ForwardedRef<HTMLAnchorElement>
   ) => {
     if (!validateLink(href)) return null
 
@@ -51,7 +57,84 @@ export const ExternalIconLink = forwardRef(
         {children}
       </a>
     )
-  },
+  }
+)
+
+interface ExternalModalLinkProps extends HTMLProps<HTMLAnchorElement> {
+  icon?: ReactNode
+  modalBody?: ReactNode
+  modalButtonTitle: string
+  modalIcon?: ReactNode
+  modalTitle?: string
+}
+
+export const ExternalModalLink = forwardRef(
+  (
+    {
+      icon,
+      children,
+      href,
+      modalBody,
+      modalButtonTitle,
+      modalIcon,
+      modalTitle,
+      ...attrs
+    }: ExternalModalLinkProps,
+    ref: ForwardedRef<HTMLAnchorElement>
+  ) => {
+    const [isModalOpen, setIsModalOpen] = useState(false)
+
+    if (!validateLink(href)) return null
+
+    const handleLinkNavigation = () => {
+      setIsModalOpen(false)
+      window.open(href, "_blank")
+    }
+
+    const setModalOpen = (open: boolean) => {
+      setIsModalOpen(open)
+    }
+
+    return (
+      <>
+        <a
+          {...attrs}
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            setModalOpen(true)
+          }}
+          ref={ref}
+        >
+          {children}
+          {icon && <CallMadeIcon fontSize="inherit" />}
+        </a>
+
+        {isModalOpen && (
+          <Modal
+            onRequestClose={(e) => {
+              setModalOpen(false)
+            }}
+            isOpen
+            icon={modalIcon}
+            closeIcon={<CloseIcon />}
+            title={modalTitle}
+            footer={() => (
+              <Submit type="button" onClick={handleLinkNavigation}>
+                {modalButtonTitle}
+              </Submit>
+            )}
+            confirm={false}
+          >
+            {modalBody}
+          </Modal>
+        )}
+      </>
+    )
+  }
 )
 
 export const validateLink = (href?: string) => {

--- a/src/components/general/index.ts
+++ b/src/components/general/index.ts
@@ -1,6 +1,6 @@
 export { default as Button } from "./Button"
 export { default as Copy } from "./Copy"
-export { ExternalLink, ExternalIconLink } from "./External"
+export { ExternalLink, ExternalIconLink, ExternalModalLink } from "./External"
 export * from "./External"
 export { default as FinderLink } from "./FinderLink"
 export * from "./FinderLink"

--- a/src/pages/gov/ProposalDescription.tsx
+++ b/src/pages/gov/ProposalDescription.tsx
@@ -1,19 +1,73 @@
 import { Proposal } from "@terra-money/terra.js"
+import WarningAmberIcon from "@mui/icons-material/WarningAmber"
+import { ExternalLink, ExternalModalLink } from "components/general"
 import xss from "xss"
+import { useTranslation } from "react-i18next"
 
 const ProposalDescription = ({ proposal }: { proposal: Proposal }) => {
   const { description } = proposal.content
-  return <p dangerouslySetInnerHTML={{ __html: linkify(description) }} />
+  const { t } = useTranslation()
+  const urlRegex = /(https?:\/\/[^\s]+)/g
+  const parts = description.split(urlRegex)
+
+  const render = () => {
+    return parts.map((part, index) => {
+      const url = xss((part.match(urlRegex) || [""])[0])
+      const isWhitelistedUrl = isWhitelisted(url)
+
+      return url ? (
+        isWhitelistedUrl ? (
+          <ExternalLink key={index} href={part}>
+            {part}
+          </ExternalLink>
+        ) : (
+          <ExternalModalLink
+            key={index}
+            href={part}
+            modalTitle={t("External Link")}
+            modalBody={
+              <>
+                <p>
+                  The link <strong>{part}</strong> is provided by the proposal
+                  author and references a website outside the Terra ecosystem.
+                </p>
+                <br />
+                <p>
+                  NEVER supply your seed phrase, password, or private key unless
+                  you are absolutely certain you are interacting with a trusted
+                  service. Releasing your seed phrase, password, or private key
+                  to a malicious actor may result in the complete loss of your
+                  wallet.
+                </p>
+              </>
+            }
+            modalButtonTitle={t("I understand, continue")}
+            modalIcon={
+              <WarningAmberIcon fontSize="inherit" className="danger" />
+            }
+          >
+            {part}
+          </ExternalModalLink>
+        )
+      ) : (
+        <span key={index}>{part}</span>
+      )
+    })
+  }
+
+  return <p>{render()}</p>
 }
 
 export default ProposalDescription
 
 /* helpers */
-const linkify = (text: string) => {
-  return xss(
-    text.replace(
-      /(https?:\/\/[^\s]+)/g,
-      '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>'
-    )
-  )
+const whitelist = [/https?:\/\/[^\.]+\.terra\.money\/[^\s]+/g]
+
+const isWhitelisted = (url: string) => {
+  for (let j = 0; j < whitelist.length; j++) {
+    if (url?.match(whitelist[j])?.length) {
+      return true
+    }
+  }
+  return false
 }

--- a/src/pages/gov/ProposalDescription.tsx
+++ b/src/pages/gov/ProposalDescription.tsx
@@ -61,7 +61,7 @@ const ProposalDescription = ({ proposal }: { proposal: Proposal }) => {
 export default ProposalDescription
 
 /* helpers */
-const whitelist = [/https?:\/\/[^\.]+\.terra\.money\/[^\s]+/g]
+const whitelist = [/https?:\/\/[^.]+\.terra\.money\/[^\s]+/g]
 
 const isWhitelisted = (url: string) => {
   for (let j = 0; j < whitelist.length; j++) {

--- a/src/pages/gov/ProposalDescription.tsx
+++ b/src/pages/gov/ProposalDescription.tsx
@@ -24,6 +24,7 @@ const ProposalDescription = ({ proposal }: { proposal: Proposal }) => {
           <ExternalModalLink
             key={index}
             href={part}
+            icon={true}
             modalTitle={t("External Link")}
             modalBody={
               <>


### PR DESCRIPTION
This PR attempts to provide additional guidance related to non-Terra links contained within governance proposal descriptions by reminding that supplying wallet seed phrases, etc. to untrusted websites may be dangerous. Users can either continue the navigation to the link, or close the dialog to cancel navigation.

Specifically, this PR modifies or introduces the following:

* Adjust ProposalDescription to render either an ExternalLink or ExternalModalLink (new) based on whether the linked URL is contained within a whitelisted set (currently *.terra.money)
* Introduce an ExternalModalLink that provides functionality for rendering a link and displaying modal UI in response to a click