### PR TITLE
Do not render external links when viewing proposal descriptions

### DIFF
--- a/src/pages/gov/ProposalDescription.module.scss
+++ b/src/pages/gov/ProposalDescription.module.scss
@@ -1,0 +1,9 @@
+@import "mixins";
+
+.mt10 {
+  margin-top: 10px;
+}
+
+.mt30 {
+  margin-top: 30px;
+}

--- a/src/pages/gov/ProposalDescription.module.scss
+++ b/src/pages/gov/ProposalDescription.module.scss
@@ -1,9 +1,0 @@
-@import "mixins";
-
-.mt10 {
-  margin-top: 10px;
-}
-
-.mt30 {
-  margin-top: 30px;
-}

--- a/src/pages/gov/ProposalDescription.tsx
+++ b/src/pages/gov/ProposalDescription.tsx
@@ -1,19 +1,100 @@
 import { Proposal } from "@terra-money/terra.js"
+import { TooltipIcon } from "components/display"
+import { Checkbox, FormHelp, FormWarning } from "components/form"
+import { ExternalLink } from "components/general"
+import { useTranslation } from "react-i18next"
+import { useState } from "react"
+import styles from "./ProposalDescription.module.scss"
 import xss from "xss"
 
 const ProposalDescription = ({ proposal }: { proposal: Proposal }) => {
   const { description } = proposal.content
-  return <p dangerouslySetInnerHTML={{ __html: linkify(description) }} />
+  const { t } = useTranslation()
+  const urlRegex = /(https?:\/\/[^\s]+)/g
+  const parts = description.split(urlRegex)
+  const [isPropRedacted, setIsPropRedacted] = useState(false)
+
+  const render = () => {
+    let externalLinkCount = 0
+
+    return (
+      <section>
+        <p>
+          {parts.map((part, index) => {
+            const url = xss((part.match(urlRegex) || [""])[0])
+            const isWhitelistedUrl = isWhitelisted(url)
+            externalLinkCount += url && !isWhitelistedUrl ? 1 : 0
+
+            return url ? (
+              isWhitelistedUrl ? (
+                <ExternalLink key={index} href={part} icon={true}>
+                  {part}
+                </ExternalLink>
+              ) : (
+                <span key={index}>
+                  {isPropRedacted ? (
+                    part
+                  ) : (
+                    <span>
+                      [
+                      <TooltipIcon
+                        content={t(
+                          "References to websites outside the Terra ecosystem are not displayed in the proposal description"
+                        )}
+                      >
+                        <em>{t("external link")}</em>
+                      </TooltipIcon>
+                      ]
+                    </span>
+                  )}
+                </span>
+              )
+            ) : (
+              <span key={index}>{part}</span>
+            )
+          })}
+        </p>
+
+        {externalLinkCount > 0 && (
+          <div className={styles.mt30}>
+            <FormHelp>
+              {t(
+                "References to websites outside the Terra ecosystem are not displayed in the proposal description"
+              )}
+            </FormHelp>
+            <FormWarning>
+              {t(
+                "Never supply your seed phrase, password, or private key to an external website unless you are absolutely certain you are interacting with a trusted service"
+              )}
+            </FormWarning>
+            <div>
+              <Checkbox
+                className={styles.mt10}
+                checked={isPropRedacted}
+                onChange={() => setIsPropRedacted(!isPropRedacted)}
+              >
+                {t("Display original proposal description")}
+              </Checkbox>
+            </div>
+          </div>
+        )}
+      </section>
+    )
+  }
+
+  return <p>{render()}</p>
 }
 
 export default ProposalDescription
 
 /* helpers */
-const linkify = (text: string) => {
-  return xss(
-    text.replace(
-      /(https?:\/\/[^\s]+)/g,
-      '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>'
-    )
-  )
+const whitelist = [/https?:\/\/[^.]+\.terra\.money\/[^\s]+/g]
+
+const isWhitelisted = (url: string) => {
+  for (let j = 0; j < whitelist.length; j++) {
+    if (url?.match(whitelist[j])?.length) {
+      return true
+    }
+  }
+  return false
 }

--- a/src/pages/gov/ProposalDescription.tsx
+++ b/src/pages/gov/ProposalDescription.tsx
@@ -1,100 +1,87 @@
+import { Fragment, useState } from "react"
+import { useTranslation } from "react-i18next"
+import xss from "xss"
 import { Proposal } from "@terra-money/terra.js"
+import { ExternalLink } from "components/general"
+import { Grid } from "components/layout"
 import { TooltipIcon } from "components/display"
 import { Checkbox, FormHelp, FormWarning } from "components/form"
-import { ExternalLink } from "components/general"
-import { useTranslation } from "react-i18next"
-import { useState } from "react"
-import styles from "./ProposalDescription.module.scss"
-import xss from "xss"
 
 const ProposalDescription = ({ proposal }: { proposal: Proposal }) => {
   const { description } = proposal.content
+
   const { t } = useTranslation()
+  const [showOriginal, setShowOriginal] = useState(false)
+
   const urlRegex = /(https?:\/\/[^\s]+)/g
   const parts = description.split(urlRegex)
-  const [isPropRedacted, setIsPropRedacted] = useState(false)
 
-  const render = () => {
-    let externalLinkCount = 0
+  const showCheckbox = !!parts.filter(
+    (part) => part.match(urlRegex) && !isWhitelisted(part)
+  ).length
 
-    return (
-      <section>
-        <p>
-          {parts.map((part, index) => {
-            const url = xss((part.match(urlRegex) || [""])[0])
-            const isWhitelistedUrl = isWhitelisted(url)
-            externalLinkCount += url && !isWhitelistedUrl ? 1 : 0
+  const renderPart = (part: string) => {
+    const url = xss(part.match(urlRegex)?.[0] ?? "")
 
-            return url ? (
-              isWhitelistedUrl ? (
-                <ExternalLink key={index} href={part} icon={true}>
-                  {part}
-                </ExternalLink>
-              ) : (
-                <span key={index}>
-                  {isPropRedacted ? (
-                    part
-                  ) : (
-                    <span>
-                      [
-                      <TooltipIcon
-                        content={t(
-                          "References to websites outside the Terra ecosystem are not displayed in the proposal description"
-                        )}
-                      >
-                        <em>{t("external link")}</em>
-                      </TooltipIcon>
-                      ]
-                    </span>
-                  )}
-                </span>
-              )
-            ) : (
-              <span key={index}>{part}</span>
-            )
-          })}
-        </p>
+    if (!url) return part
 
-        {externalLinkCount > 0 && (
-          <div className={styles.mt30}>
-            <FormHelp>
-              {t(
-                "References to websites outside the Terra ecosystem are not displayed in the proposal description"
-              )}
-            </FormHelp>
-            <FormWarning>
-              {t(
-                "Never supply your seed phrase, password, or private key to an external website unless you are absolutely certain you are interacting with a trusted service"
-              )}
-            </FormWarning>
-            <div>
-              <Checkbox
-                className={styles.mt10}
-                checked={isPropRedacted}
-                onChange={() => setIsPropRedacted(!isPropRedacted)}
-              >
-                {t("Display original proposal description")}
-              </Checkbox>
-            </div>
-          </div>
+    if (isWhitelisted(url))
+      return (
+        <ExternalLink href={part} icon={true}>
+          {part}
+        </ExternalLink>
+      )
+
+    if (showOriginal) return part
+
+    const tooltip = (
+      <TooltipIcon
+        content={t(
+          "References to websites outside the Terra ecosystem are not displayed in the proposal description"
         )}
-      </section>
+      >
+        <i>{t("external link")}</i>
+      </TooltipIcon>
     )
+
+    return <>[{tooltip}]</>
   }
 
-  return <p>{render()}</p>
+  return (
+    <Grid gap={20}>
+      <p>
+        {parts.map((part, index) => (
+          <Fragment key={index}>{renderPart(part)}</Fragment>
+        ))}
+      </p>
+
+      {showCheckbox && (
+        <Grid gap={4}>
+          <FormHelp>
+            {t(
+              "References to websites outside the Terra ecosystem are not displayed in the proposal description"
+            )}
+          </FormHelp>
+          <FormWarning>
+            {t(
+              "Never supply your seed phrase, password, or private key to an external website unless you are absolutely certain you are interacting with a trusted service"
+            )}
+          </FormWarning>
+          <Checkbox
+            checked={showOriginal}
+            onChange={() => setShowOriginal(!showOriginal)}
+          >
+            {t("Display original proposal description")}
+          </Checkbox>
+        </Grid>
+      )}
+    </Grid>
+  )
 }
 
 export default ProposalDescription
 
-/* helpers */
-const whitelist = [/https?:\/\/[^.]+\.terra\.money\/[^\s]+/g]
-
-const isWhitelisted = (url: string) => {
-  for (let j = 0; j < whitelist.length; j++) {
-    if (url?.match(whitelist[j])?.length) {
-      return true
-    }
-  }
-  return false
+const isWhitelisted = (url?: string) => {
+  if (!url) return false
+  return new URL(url).hostname.endsWith("terra.money")
 }

--- a/src/txs/gov/SubmitProposalForm.tsx
+++ b/src/txs/gov/SubmitProposalForm.tsx
@@ -368,6 +368,8 @@ const SubmitProposalForm = ({ communityPool, minDeposit }: Props) => {
     }
   }
 
+  const agoraURL = isClassic ? "classic-agora.terra.money" : "agora.terra.money"
+
   return (
     <Tx {...tx}>
       {({ max, fee, submit }) => (
@@ -375,14 +377,8 @@ const SubmitProposalForm = ({ communityPool, minDeposit }: Props) => {
           <Grid gap={4}>
             <FormHelp>
               Upload proposal only after forum discussion on{" "}
-              <ExternalLink
-                href={
-                  isClassic
-                    ? "https://classic-agora.terra.money"
-                    : "https://agora.terra.money"
-                }
-              >
-                {isClassic ? "classic-" : ""}agora.terra.money
+              <ExternalLink href={`https://${agoraURL}`}>
+                {agoraURL}
               </ExternalLink>
             </FormHelp>
             <FormWarning>

--- a/src/txs/gov/SubmitProposalForm.tsx
+++ b/src/txs/gov/SubmitProposalForm.tsx
@@ -13,7 +13,7 @@ import { SAMPLE_ADDRESS } from "config/constants"
 import { getAmount, sortCoins } from "utils/coin"
 import { has } from "utils/num"
 import { parseJSON } from "utils/data"
-import { queryKey } from "data/query"
+import { queryKey, useIsClassic } from "data/query"
 import { useAddress } from "data/wallet"
 import { useBankBalance } from "data/queries/bank"
 import { ExternalLink } from "components/general"
@@ -77,6 +77,7 @@ interface Props {
 const SubmitProposalForm = ({ communityPool, minDeposit }: Props) => {
   const { t } = useTranslation()
   const address = useAddress()
+  const isClassic = useIsClassic()
 
   const bankBalance = useBankBalance()
   const balance = getAmount(bankBalance, "uluna")
@@ -374,8 +375,14 @@ const SubmitProposalForm = ({ communityPool, minDeposit }: Props) => {
           <Grid gap={4}>
             <FormHelp>
               Upload proposal only after forum discussion on{" "}
-              <ExternalLink href="https://agora.terra.money">
-                agora.terra.money
+              <ExternalLink
+                href={
+                  isClassic
+                    ? "https://classic-agora.terra.money"
+                    : "https://agora.terra.money"
+                }
+              >
+                {isClassic ? "classic-" : ""}agora.terra.money
               </ExternalLink>
             </FormHelp>
             <FormWarning>
@@ -388,6 +395,11 @@ const SubmitProposalForm = ({ communityPool, minDeposit }: Props) => {
                 {t("Parameters cannot be changed by text proposals")}
               </FormWarning>
             )}
+            <FormWarning>
+              {t(
+                "Links to websites outside the Terra ecosystem will not be displayed"
+              )}
+            </FormWarning>
           </Grid>
 
           <FormItem label={t("Proposal type")} error={errors.type?.message}>


### PR DESCRIPTION
This PR adjusts proposal descriptions to avoid rendering of links to resources outside the Terra ecosystem in an effort to deter scam proposals. Informational messages are added, and the ability to view a text-only representation of the proposal description is available.

See https://classic-agora.terra.money/t/initiative-to-stop-scam-proposals/47642/19 and https://station.terra.money/proposal/7101for additional context.