### PR TITLE
fix: Implement pagination on governance tabs

### DIFF
--- a/src/data/queries/gov.ts
+++ b/src/data/queries/gov.ts
@@ -6,6 +6,7 @@ import { Proposal, Vote } from "@terra-money/terra.js"
 import { Color } from "types/components"
 import { Pagination, queryKey, RefetchOptions, useIsClassic } from "../query"
 import { useLCDClient } from "./lcdClient"
+import { PaginationOptions } from "@terra-money/terra.js/dist/client/lcd/APIRequester"
 
 export const useVotingParams = () => {
   const lcd = useLCDClient()
@@ -33,21 +34,23 @@ export const useTallyParams = () => {
 }
 
 /* proposals */
-export const useProposals = (status: Proposal.Status) => {
+export const useProposals = (
+  status: Proposal.Status,
+  paginationOptions: Partial<PaginationOptions>
+) => {
   const lcd = useLCDClient()
+
   return useQuery(
-    [queryKey.gov.proposals, status],
+    [queryKey.gov.proposals, status, paginationOptions],
     async () => {
-      // TODO: Pagination
-      // Required when the number of results exceed 100
-      // About 50 passed propsals from 2019 to 2021
-      const [proposals] = await lcd.gov.proposals({
+      const proposals = await lcd.gov.proposals({
         proposal_status: status,
         ...Pagination,
+        ...paginationOptions,
       })
       return proposals
     },
-    { ...RefetchOptions.DEFAULT }
+    { ...RefetchOptions.DEFAULT, keepPreviousData: true }
   )
 }
 

--- a/src/pages/gov/ProposalsByStatus.module.scss
+++ b/src/pages/gov/ProposalsByStatus.module.scss
@@ -17,3 +17,9 @@
     text-decoration: none;
   }
 }
+
+/* pagination */
+.pagination {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/src/pages/gov/ProposalsByStatus.tsx
+++ b/src/pages/gov/ProposalsByStatus.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { reverse } from "ramda"
 import { Proposal } from "@terra-money/terra.js"
 import { combineState } from "data/query"
 import { useProposals, useProposalStatusItem } from "data/queries/gov"
@@ -12,30 +11,136 @@ import ProposalItem from "./ProposalItem"
 import GovernanceParams from "./GovernanceParams"
 import styles from "./ProposalsByStatus.module.scss"
 import { useNetworkName } from "data/wallet"
+import PaginationButtons from "components/layout/PaginationButtons"
+import { ProposalStatus } from "@terra-money/terra.proto/cosmos/gov/v1beta1/gov"
+
+interface PaginationState {
+  key: string
+  stack: string[]
+  status: ProposalStatus
+  total: number
+}
 
 const ProposalsByStatus = ({ status }: { status: Proposal.Status }) => {
   const { t } = useTranslation()
   const networkName = useNetworkName()
 
-  const { data: whitelistData, ...whitelistState } = useTerraAssets<{ [key: string]: number[] }> ("/station/proposals.json")
+  const { data: whitelistData, ...whitelistState } = useTerraAssets<{
+    [key: string]: number[]
+  }>("/station/proposals.json")
   const whitelist = whitelistData?.[networkName]
 
   const [showAll, setShowAll] = useState(!!whitelist)
   const toggle = () => setShowAll((state) => !state)
 
+  const pagination = 6
+  const [paginationState, setPaginationState] = useState<PaginationState>()
+  const key = (paginationState && paginationState.key) || ""
+  const pageStack = (paginationState && paginationState.stack) || []
+  const page = pageStack.length + 1
+  const total = (paginationState && paginationState.total) || 0
 
-  const { data, ...proposalState } = useProposals(status)
+  /* reset pagination on status change */
+  useEffect(() => {
+    const pagination = JSON.parse(
+      window.localStorage.getItem("pagination-gov") || "{}"
+    )
+
+    setPaginationState(
+      pagination.status === status
+        ? pagination
+        : {
+            key: "",
+            stack: [],
+            status: status,
+            total: 0,
+          }
+    )
+  }, [status])
+
+  useEffect(() => {
+    window.localStorage.setItem(
+      "pagination-gov",
+      JSON.stringify(paginationState)
+    )
+  }, [paginationState])
+
+  const { data, ...proposalState } = useProposals(status, {
+    "pagination.count_total": "true",
+    "pagination.reverse": "true",
+    "pagination.limit": String(pagination),
+    "pagination.key": key,
+  })
+  const [proposalData, paginationData] = data || []
+
+  if (
+    paginationData &&
+    paginationData.total > 0 &&
+    paginationData.total !== total
+  ) {
+    setPaginationState(
+      Object.assign({}, paginationState, { total: paginationData.total })
+    )
+  }
+
   const { label } = useProposalStatusItem(status)
 
   const state = combineState(whitelistState, proposalState)
 
+  /* pagination */
+  const handleNext = () => {
+    if (!(paginationState && paginationData && paginationData.next_key))
+      return null
+    if (paginationData.next_key === key) return
+
+    setPaginationState(
+      Object.assign({}, paginationState, {
+        stack: [...pageStack, paginationData.next_key],
+        key: paginationData.next_key,
+        status: status,
+        page: page + 1,
+      })
+    )
+  }
+
+  const handlePrevious = () => {
+    setPaginationState(
+      Object.assign({}, paginationState, {
+        stack: pageStack.slice(0, pageStack.length - 1),
+        key: pageStack.reverse()[1],
+        status: status,
+        page: page - 1,
+      })
+    )
+  }
+
+  const renderPagination = () => {
+    if (!(pagination && paginationData)) return null
+    const recordTotal = Math.ceil(total / pagination)
+
+    if (!recordTotal || recordTotal === 1) return null
+    const prevPage = page > 1 ? () => handlePrevious() : undefined
+    const nextPage = page < total ? () => handleNext() : undefined
+
+    return (
+      <footer className={styles.pagination}>
+        <PaginationButtons
+          current={page}
+          total={recordTotal}
+          onPrev={prevPage}
+          onNext={nextPage}
+        />
+      </footer>
+    )
+  }
+
   const render = () => {
-    if (!(data && whitelistData)) return null
+    if (!(proposalData && whitelistData)) return null
 
     const proposals =
       status === Proposal.Status.PROPOSAL_STATUS_VOTING_PERIOD && !showAll
-        ? data.filter(({ id }) => whitelist?.includes(id))
-        : data
+        ? proposalData.filter(({ id }) => whitelist?.includes(id))
+        : proposalData
 
     return !proposals.length ? (
       <>
@@ -51,12 +156,18 @@ const ProposalsByStatus = ({ status }: { status: Proposal.Status }) => {
     ) : (
       <>
         <section className={styles.list}>
-          {reverse(proposals).map((item) => (
-            <Card to={`/proposal/${item.id}`} className={styles.link} key={item.id}>
+          {proposals.map((item) => (
+            <Card
+              to={`/proposal/${item.id}`}
+              className={styles.link}
+              key={item.id}
+            >
               <ProposalItem proposal={item} showVotes={!showAll} />
             </Card>
           ))}
         </section>
+
+        {renderPagination()}
 
         <GovernanceParams />
       </>
@@ -66,13 +177,14 @@ const ProposalsByStatus = ({ status }: { status: Proposal.Status }) => {
   return (
     <Fetching {...state}>
       <Col>
-        {!!whitelist && status === Proposal.Status.PROPOSAL_STATUS_VOTING_PERIOD && (
-          <section>
-            <Toggle checked={showAll} onChange={toggle}>
-              {t("Show all")}
-            </Toggle>
-          </section>
-        )}
+        {!!whitelist &&
+          status === Proposal.Status.PROPOSAL_STATUS_VOTING_PERIOD && (
+            <section>
+              <Toggle checked={showAll} onChange={toggle}>
+                {t("Show all")}
+              </Toggle>
+            </section>
+          )}
 
         {render()}
       </Col>


### PR DESCRIPTION
Presently, the governance tabs display the first LAZY_LIMIT (999) proposals in a descending order. For those proposal statuses with more than 999 items (currently on the Classic network: Rejected, Deposit), only the the first 999 items are displayed in descending order, leaving more recent items in these states not visible in the Governance module.

The proposed PR introduces paging for the governance module, displaying 6 proposals per page for those statuses with multiple items. Recoil state is utilized to ensure that paging through proposals, visiting a proposal, and then returning to the list of proposals via browser back button results in the view maintaining paging state.