### PR TITLE
Fix: increase default icon size in TokenIcon comp

### DIFF
--- a/src/components/token/TokenIcon.tsx
+++ b/src/components/token/TokenIcon.tsx
@@ -27,9 +27,9 @@ const TokenIcon = ({ token, icon, size, ...rest }: Props) => {
     size === "inherit"
       ? undefined
       : {
-          width: size ?? 24,
-          height: size ?? 24,
-          style: { padding: (size ?? 24) / 3.5 },
+          width: size ?? 34,
+          height: size ?? 34,
+          style: { padding: (size ?? 34) / 3.5 },
         }
 
   const attrs = { ...rest, ...sizes, src, className: cx(styles.icon, size) }


### PR DESCRIPTION
previous was too small on swap screen. could also pass around a `iconSize` prop but felt this was cleaner. 