### PR TITLE
Improve existing URL regex for detecting URLs in governance proposal descriptions, to include fuzzy URL matching with or without protocol prefix

### DIFF
--- a/src/data/queries/gov.ts
+++ b/src/data/queries/gov.ts
@@ -6,6 +6,7 @@ import { Proposal, Vote } from "@terra-money/terra.js"
 import { Color } from "types/components"
 import { Pagination, queryKey, RefetchOptions, useIsClassic } from "../query"
 import { useLCDClient } from "./lcdClient"
+import { PaginationOptions } from "@terra-money/terra.js/dist/client/lcd/APIRequester"
 
 export const useVotingParams = () => {
   const lcd = useLCDClient()
@@ -33,21 +34,23 @@ export const useTallyParams = () => {
 }
 
 /* proposals */
-export const useProposals = (status: Proposal.Status) => {
+export const useProposals = (
+  status: Proposal.Status,
+  paginationOptions: Partial<PaginationOptions>
+) => {
   const lcd = useLCDClient()
+
   return useQuery(
-    [queryKey.gov.proposals, status],
+    [queryKey.gov.proposals, status, paginationOptions],
     async () => {
-      // TODO: Pagination
-      // Required when the number of results exceed 100
-      // About 50 passed propsals from 2019 to 2021
-      const [proposals] = await lcd.gov.proposals({
+      const proposals = await lcd.gov.proposals({
         proposal_status: status,
         ...Pagination,
+        ...paginationOptions,
       })
       return proposals
     },
-    { ...RefetchOptions.DEFAULT }
+    { ...RefetchOptions.DEFAULT, keepPreviousData: true }
   )
 }
 

--- a/src/pages/gov/ProposalDescription.tsx
+++ b/src/pages/gov/ProposalDescription.tsx
@@ -1,19 +1,87 @@
-import { Proposal } from "@terra-money/terra.js"
+import { Fragment, useState } from "react"
+import { useTranslation } from "react-i18next"
 import xss from "xss"
+import { Proposal } from "@terra-money/terra.js"
+import { ExternalLink } from "components/general"
+import { Grid } from "components/layout"
+import { TooltipIcon } from "components/display"
+import { Checkbox, FormHelp, FormWarning } from "components/form"
 
 const ProposalDescription = ({ proposal }: { proposal: Proposal }) => {
   const { description } = proposal.content
-  return <p dangerouslySetInnerHTML={{ __html: linkify(description) }} />
+
+  const { t } = useTranslation()
+  const [showOriginal, setShowOriginal] = useState(false)
+
+  const urlRegex = /(https?:\/\/[^\s]+)/g
+  const parts = description.split(urlRegex)
+
+  const showCheckbox = !!parts.filter(
+    (part) => part.match(urlRegex) && !isWhitelisted(part)
+  ).length
+
+  const renderPart = (part: string) => {
+    const url = xss(part.match(urlRegex)?.[0] ?? "")
+
+    if (!url) return part
+
+    if (isWhitelisted(url))
+      return (
+        <ExternalLink href={part} icon={true}>
+          {part}
+        </ExternalLink>
+      )
+
+    if (showOriginal) return part
+
+    const tooltip = (
+      <TooltipIcon
+        content={t(
+          "References to websites outside the Terra ecosystem are not displayed in the proposal description"
+        )}
+      >
+        <i>{t("external link")}</i>
+      </TooltipIcon>
+    )
+
+    return <>[{tooltip}]</>
+  }
+
+  return (
+    <Grid gap={20}>
+      <p>
+        {parts.map((part, index) => (
+          <Fragment key={index}>{renderPart(part)}</Fragment>
+        ))}
+      </p>
+
+      {showCheckbox && (
+        <Grid gap={4}>
+          <FormHelp>
+            {t(
+              "References to websites outside the Terra ecosystem are not displayed in the proposal description"
+            )}
+          </FormHelp>
+          <FormWarning>
+            {t(
+              "Never supply your seed phrase, password, or private key to an external website unless you are absolutely certain you are interacting with a trusted service"
+            )}
+          </FormWarning>
+          <Checkbox
+            checked={showOriginal}
+            onChange={() => setShowOriginal(!showOriginal)}
+          >
+            {t("Display original proposal description")}
+          </Checkbox>
+        </Grid>
+      )}
+    </Grid>
+  )
 }
 
 export default ProposalDescription
 
-/* helpers */
-const linkify = (text: string) => {
-  return xss(
-    text.replace(
-      /(https?:\/\/[^\s]+)/g,
-      '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>'
-    )
-  )
+const isWhitelisted = (url?: string) => {
+  if (!url) return false
+  return new URL(url).hostname.endsWith("terra.money")
 }

--- a/src/pages/gov/ProposalVotes.tsx
+++ b/src/pages/gov/ProposalVotes.tsx
@@ -182,8 +182,10 @@ const calcTallies = (
     ? { x: quorum.toNumber(), type: "quorum" as const }
     : { x: thresholdX, type: "threshold" as const }
 
-  const consentRatio = list.slice(0, 2).map(({ ratio }) => ratio.byVoted)
-  const isPassing = !isBelowQuorum && BigNumber.sum(...consentRatio).gte(0.5)
+  const yesRatio = list[0].ratio.byVoted
+  const noRatio = list.slice(2, 4).map(({ ratio }) => ratio.byVoted)
+
+  const isPassing = !isBelowQuorum && BigNumber.sum(...noRatio).lte(yesRatio)
 
   return { list, total: { ...total, ratio }, flag, isPassing }
 }

--- a/src/pages/gov/ProposalsByStatus.module.scss
+++ b/src/pages/gov/ProposalsByStatus.module.scss
@@ -17,3 +17,9 @@
     text-decoration: none;
   }
 }
+
+/* pagination */
+.pagination {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/src/pages/gov/ProposalsByStatus.tsx
+++ b/src/pages/gov/ProposalsByStatus.tsx
@@ -1,41 +1,147 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { reverse } from "ramda"
+import { atom, useRecoilState } from "recoil"
 import { Proposal } from "@terra-money/terra.js"
 import { combineState } from "data/query"
 import { useProposals, useProposalStatusItem } from "data/queries/gov"
 import { useTerraAssets } from "data/Terra/TerraAssets"
 import { Col, Card } from "components/layout"
+import PaginationButtons from "components/layout/PaginationButtons"
 import { Fetching, Empty } from "components/feedback"
 import { Toggle } from "components/form"
 import ProposalItem from "./ProposalItem"
 import GovernanceParams from "./GovernanceParams"
-import styles from "./ProposalsByStatus.module.scss"
 import { useNetworkName } from "data/wallet"
+import styles from "./ProposalsByStatus.module.scss"
+
+const DefaultGovernancePaginationState = {
+  key: "",
+  stack: [],
+  status: undefined,
+  total: 0,
+}
+
+const governancePaginationState = atom({
+  key: "governancePaginationState",
+  default: DefaultGovernancePaginationState,
+})
 
 const ProposalsByStatus = ({ status }: { status: Proposal.Status }) => {
   const { t } = useTranslation()
   const networkName = useNetworkName()
 
-  const { data: whitelistData, ...whitelistState } = useTerraAssets<{ [key: string]: number[] }> ("/station/proposals.json")
+  const { data: whitelistData, ...whitelistState } = useTerraAssets<{
+    [key: string]: number[]
+  }>("/station/proposals.json")
   const whitelist = whitelistData?.[networkName]
 
   const [showAll, setShowAll] = useState(!!whitelist)
   const toggle = () => setShowAll((state) => !state)
 
+  const pagination = 6
+  const [paginationState, setPaginationState] = useRecoilState(
+    governancePaginationState
+  )
+  const key = (paginationState && paginationState.key) || ""
+  const pageStack = (paginationState && paginationState.stack) || []
+  const page = pageStack.length + 1
+  const total = (paginationState && paginationState.total) || 0
 
-  const { data, ...proposalState } = useProposals(status)
+  /* reset pagination on status change */
+  useEffect(() => {
+    if (
+      !(
+        paginationState &&
+        paginationState.status &&
+        paginationState.status !== status
+      )
+    )
+      return
+
+    setPaginationState(DefaultGovernancePaginationState)
+  }, [paginationState, setPaginationState, status])
+
+  const { data, ...proposalState } = useProposals(status, {
+    "pagination.count_total": "true",
+    "pagination.reverse": "true",
+    "pagination.limit": String(pagination),
+    "pagination.key": key,
+  })
+  const [proposalData, paginationData] = data || []
+
+  useEffect(() => {
+    if (
+      !(
+        paginationData &&
+        paginationData.total > 0 &&
+        paginationData.total !== total
+      )
+    )
+      return
+
+    setPaginationState(
+      Object.assign({}, paginationState, { total: paginationData.total })
+    )
+  }, [paginationData, paginationState, setPaginationState, total])
+
   const { label } = useProposalStatusItem(status)
 
   const state = combineState(whitelistState, proposalState)
 
+  /* pagination */
+  const handleNext = () => {
+    if (!(paginationState && paginationData && paginationData.next_key))
+      return null
+    if (paginationData.next_key === key) return
+
+    setPaginationState(
+      Object.assign({}, paginationState, {
+        stack: [...pageStack, paginationData.next_key],
+        key: paginationData.next_key,
+        status: status,
+        page: page + 1,
+      })
+    )
+  }
+
+  const handlePrevious = () => {
+    setPaginationState(
+      Object.assign({}, paginationState, {
+        stack: pageStack.slice(0, pageStack.length - 1),
+        key: [...pageStack].reverse()[1],
+        status: status,
+        page: page - 1,
+      })
+    )
+  }
+
+  const renderPagination = () => {
+    if (!(pagination && paginationData)) return null
+    const recordTotal = Math.ceil(total / pagination)
+
+    if (!recordTotal || recordTotal === 1) return null
+    const prevPage = page > 1 ? () => handlePrevious() : undefined
+    const nextPage = page < total ? () => handleNext() : undefined
+
+    return (
+      <footer className={styles.pagination}>
+        <PaginationButtons
+          current={page}
+          total={recordTotal}
+          onPrev={prevPage}
+          onNext={nextPage}
+        />
+      </footer>
+    )
+  }
+
   const render = () => {
-    if (!(data && whitelistData)) return null
+    if (!(proposalData && whitelistData)) return null
 
     const proposals =
       status === Proposal.Status.PROPOSAL_STATUS_VOTING_PERIOD && !showAll
-        ? data.filter(({ id }) => whitelist?.includes(id))
-        : data
+        ? proposalData.filter(({ id }) => whitelist?.includes(id))
+        : proposalData
 
     return !proposals.length ? (
       <>
@@ -51,12 +157,18 @@ const ProposalsByStatus = ({ status }: { status: Proposal.Status }) => {
     ) : (
       <>
         <section className={styles.list}>
-          {reverse(proposals).map((item) => (
-            <Card to={`/proposal/${item.id}`} className={styles.link} key={item.id}>
+          {proposals.map((item) => (
+            <Card
+              to={`/proposal/${item.id}`}
+              className={styles.link}
+              key={item.id}
+            >
               <ProposalItem proposal={item} showVotes={!showAll} />
             </Card>
           ))}
         </section>
+
+        {renderPagination()}
 
         <GovernanceParams />
       </>
@@ -66,13 +178,14 @@ const ProposalsByStatus = ({ status }: { status: Proposal.Status }) => {
   return (
     <Fetching {...state}>
       <Col>
-        {!!whitelist && status === Proposal.Status.PROPOSAL_STATUS_VOTING_PERIOD && (
-          <section>
-            <Toggle checked={showAll} onChange={toggle}>
-              {t("Show all")}
-            </Toggle>
-          </section>
-        )}
+        {!!whitelist &&
+          status === Proposal.Status.PROPOSAL_STATUS_VOTING_PERIOD && (
+            <section>
+              <Toggle checked={showAll} onChange={toggle}>
+                {t("Show all")}
+              </Toggle>
+            </section>
+          )}
 
         {render()}
       </Col>

--- a/src/txs/gov/SubmitProposalForm.tsx
+++ b/src/txs/gov/SubmitProposalForm.tsx
@@ -13,7 +13,7 @@ import { SAMPLE_ADDRESS } from "config/constants"
 import { getAmount, sortCoins } from "utils/coin"
 import { has } from "utils/num"
 import { parseJSON } from "utils/data"
-import { queryKey } from "data/query"
+import { queryKey, useIsClassic } from "data/query"
 import { useAddress } from "data/wallet"
 import { useBankBalance } from "data/queries/bank"
 import { ExternalLink } from "components/general"
@@ -77,6 +77,7 @@ interface Props {
 const SubmitProposalForm = ({ communityPool, minDeposit }: Props) => {
   const { t } = useTranslation()
   const address = useAddress()
+  const isClassic = useIsClassic()
 
   const bankBalance = useBankBalance()
   const balance = getAmount(bankBalance, "uluna")
@@ -367,6 +368,8 @@ const SubmitProposalForm = ({ communityPool, minDeposit }: Props) => {
     }
   }
 
+  const agoraURL = isClassic ? "classic-agora.terra.money" : "agora.terra.money"
+
   return (
     <Tx {...tx}>
       {({ max, fee, submit }) => (
@@ -374,8 +377,8 @@ const SubmitProposalForm = ({ communityPool, minDeposit }: Props) => {
           <Grid gap={4}>
             <FormHelp>
               Upload proposal only after forum discussion on{" "}
-              <ExternalLink href="https://agora.terra.money">
-                agora.terra.money
+              <ExternalLink href={`https://${agoraURL}`}>
+                {agoraURL}
               </ExternalLink>
             </FormHelp>
             <FormWarning>
@@ -388,6 +391,11 @@ const SubmitProposalForm = ({ communityPool, minDeposit }: Props) => {
                 {t("Parameters cannot be changed by text proposals")}
               </FormWarning>
             )}
+            <FormWarning>
+              {t(
+                "Links to websites outside the Terra ecosystem will not be displayed"
+              )}
+            </FormWarning>
           </Grid>
 
           <FormItem label={t("Proposal type")} error={errors.type?.message}>

--- a/src/utils/gov.ts
+++ b/src/utils/gov.ts
@@ -1,0 +1,24 @@
+export const isWhitelisted = (url?: string) => {
+  if (!url) return false
+  if (!url.match(/https?:\/\/.*/)) {
+    url = `https://${url}`
+  }
+
+  try {
+    return new URL(url).hostname.endsWith("terra.money")
+  } catch (error) {
+    return false
+  }
+}
+
+/* exempted URLs are displayed as written (but not linked) */
+export const isExempted = (url?: string) => {
+  const exempted = ["terra.py"]
+  if (!url) return false
+
+  return exempted.includes(url.toLowerCase())
+}
+
+/* include 2 and 3 character domains + .money as anchor TLDs for url detection; based on https://data.iana.org/TLD/tlds-alpha-by-domain.txt */
+export const URL_REGEX =
+  /((?:https?:\/\/)?(?:[A-Z0-9-]+?\s*\.\s*)*?(?:\b[A-Z0-9-]{1,63}?)(?:(?:\s*\.(?:am|an|as|at|be|by|do|it|in|is|how|new|no|one|so|top|to))|(?:\s*\.\s*(?:ads|afl|app|axa|ac|ad|ae|af|ag|ai|al|ao|aq|ar|au|aw|ax|az|bar|bbc|bid|bio|biz|bmw|boo|bzh|ba|bb|bd|bf|bg|bh|bi|bj|bl|bm|bn|bo|bq|br|bs|bt|bv|bw|bz|cab|cal|cat|cbn|ceo|cfd|com|crs|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|co|cr|cu|cv|cw|cx|cy|cz|dad|day|dev|dnp|de|dj|dk|dm|dz|eat|edu|esq|eus|ec|ee|eg|eh|er|es|et|eu|fan|fit|fly|foo|frl|fi|fj|fk|fm|fo|fr|gal|gdn|gle|gmo|gmx|goo|gop|gov|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn|gp|gq|gr|gs|gt|gu|gw|gy|hiv|hk|hm|hn|hr|ht|hu|ibm|ifm|ing|ink|int|iwc|id|ie|il|im|io|iq|ir|jcb|je|jm|jo|jp|kim|krd|ke|kg|kh|ki|km|kn|kp|kr|kw|ky|kz|lat|lds|la|lb|lc|li|lk|lr|ls|lt|lu|lv|ly|money|mil|mma|moe|mov|mtn|ma|mc|md|me|mf|mg|mh|mk|ml|mm|mn|mo|mp|mq|mr|ms|mt|mu|mv|mw|mx|my|mz|net|ngo|nhk|nra|nrw|ntt|nyc|na|nc|ne|nf|ng|ni|nl|np|nr|nu|nz|ong|onl|ooo|org|ovh|om|pro|pub|pa|pe|pf|pg|ph|pk|pl|pm|pn|pr|ps|pt|pw|py|qa|red|ren|rio|rip|re|ro|rs|ru|rw|sap|sca|scb|sew|sky|soy|sa|sb|sc|sd|se|sg|sh|si|sj|sk|sl|sm|sn|sr|ss|st|su|sv|sx|sy|sz|tax|tel|tui|tc|td|tf|tg|th|tj|tk|tl|tm|tn|tp|tr|tt|tv|tw|z|uno|uol|ua|ug|uk|um|us|uy|uz|vet|va|vc|ve|vg|vi|vn|vu|wed|win|wme|wtc|wtf|wf|ws|xin|xxx|xyz|ye|yt|zip|za|zm|zw))+?\b)(?:\/[^.!,?;"'<>()[\]{}\s\x7F-\xFF]*(?:[.!,?]+[^.!,?;"'<>()[\]{}\s\x7F-\xFF]+)*)?)/gi

--- a/src/utils/gov.ts
+++ b/src/utils/gov.ts
@@ -5,7 +5,8 @@ export const isWhitelisted = (url?: string) => {
   }
 
   try {
-    return new URL(url).hostname.endsWith("terra.money")
+    const hostname = new URL(url).hostname
+    return hostname === "terra.money" || hostname.endsWith(".terra.money")
   } catch (error) {
     return false
   }


### PR DESCRIPTION
The original regex used to detect links in governance proposal descriptions assumed a mandatory protocol (http/https) prefix. A number of scam proposals work around the [external url] flag by omitting the protocol handler, allowing for URLs to be displayed. This PR introduced a fuzzy URL detection regex that attempts to remain neutral toward non-URL phrases, while still flagging possible obfuscated URL patterns with spaces (host.  example. com, or similar).

Specifically, this PR:

- Adjusts the regular expression used to detect URLs to anchor on known 2 and 3 character top level domains, allowing for detection of potentially obfuscated URLs with spaces
- Adjusts display of tooltips in proposal descriptions to include the specific URL that was not displayed
- Adjusts proposal submission form to indicate to user that a potential URL was detected in description input
- Refactors repeated logic functions (isExempted(), isWhitelisted()) to a gov util file referenced by both the description and new governance submission forms to eliminate duplication of code related to URL regex detection