### PR TITLE
Feature: Implement external url warnings and whitelists for proposal descriptions

### DIFF
--- a/src/pages/gov/ProposalDescription.tsx
+++ b/src/pages/gov/ProposalDescription.tsx
@@ -9,11 +9,11 @@ import { Checkbox, FormHelp, FormWarning } from "components/form"
 import { Grid } from "components/layout"
 
 const ProposalDescription = ({ proposal }: { proposal: ProposalResult }) => {
-  if (!proposal.content) return null
-  const { description } = proposal.content
-
   const { t } = useTranslation()
   const [showOriginal, setShowOriginal] = useState(false)
+
+  if (!proposal.content) return null
+  const { description } = proposal.content
 
   const parts = description.split(URL_REGEX)
 

--- a/src/pages/gov/ProposalDescription.tsx
+++ b/src/pages/gov/ProposalDescription.tsx
@@ -1,20 +1,87 @@
+import { Fragment, useState } from "react"
 import { ProposalResult } from "data/queries/gov"
+import { useTranslation } from "react-i18next"
 import xss from "xss"
+import { isExempted, isWhitelisted, URL_REGEX } from "utils/gov"
+import { ExternalLink } from "components/general"
+import { TooltipIcon } from "components/display"
+import { Checkbox, FormHelp, FormWarning } from "components/form"
+import { Grid } from "components/layout"
 
 const ProposalDescription = ({ proposal }: { proposal: ProposalResult }) => {
   if (!proposal.content) return null
   const { description } = proposal.content
-  return <p dangerouslySetInnerHTML={{ __html: linkify(description) }} />
+
+  const { t } = useTranslation()
+  const [showOriginal, setShowOriginal] = useState(false)
+
+  const parts = description.split(URL_REGEX)
+
+  const showCheckbox = !!parts.filter(
+    (part) => part.match(URL_REGEX) && !isWhitelisted(part) && !isExempted(part)
+  ).length
+
+  const renderPart = (part: string) => {
+    const url = xss(part.match(URL_REGEX)?.[0] ?? "")
+
+    if (!url) return part
+    if (isExempted(url)) return part
+
+    if (
+      isWhitelisted(url) ||
+      (part.toLowerCase().startsWith("https") && showOriginal)
+    )
+      return (
+        <ExternalLink href={part} icon={true}>
+          {part}
+        </ExternalLink>
+      )
+
+    if (showOriginal) return part
+
+    const tooltip = (
+      <TooltipIcon
+        content={t(
+          `A potential reference to a website outside Station (${part}) was not displayed in the proposal description. See guidance below if you intend to visit this website.`
+        )}
+      >
+        <i>{t("external link")}</i>
+      </TooltipIcon>
+    )
+
+    return <>[{tooltip}]</>
+  }
+
+  return (
+    <Grid gap={20}>
+      <p>
+        {parts.map((part, index) => (
+          <Fragment key={index}>{renderPart(part)}</Fragment>
+        ))}
+      </p>
+
+      {showCheckbox && (
+        <Grid gap={4}>
+          <FormHelp>
+            {t(
+              "References to websites outside Station are not displayed in the proposal description"
+            )}
+          </FormHelp>
+          <FormWarning>
+            {t(
+              "Never supply your seed phrase, password, or private key to an external website unless you are absolutely certain you are interacting with a trusted service"
+            )}
+          </FormWarning>
+          <Checkbox
+            checked={showOriginal}
+            onChange={() => setShowOriginal(!showOriginal)}
+          >
+            {t("Display original proposal description")}
+          </Checkbox>
+        </Grid>
+      )}
+    </Grid>
+  )
 }
 
 export default ProposalDescription
-
-/* helpers */
-const linkify = (text: string) => {
-  return xss(
-    text.replace(
-      /(https?:\/\/[^\s]+)/g,
-      '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>'
-    )
-  )
-}

--- a/src/utils/gov.ts
+++ b/src/utils/gov.ts
@@ -1,0 +1,42 @@
+export const isWhitelisted = (url?: string) => {
+  if (!url) return false
+  if (!url.match(/https?:\/\/.*/)) {
+    url = `https://${url}`
+  }
+
+  /* common interchain proposal discussion forums or resources */
+  const whitelistedDomains = [
+    "commonwealth.im",
+    "github.com",
+    "mintscan.io",
+    "terra.dev",
+    "terra.money",
+    "terragrantsfoundation.org",
+  ]
+
+  try {
+    const hostname = new URL(url).hostname
+    var whitelisted = false
+
+    whitelistedDomains.forEach((domain) => {
+      if (hostname === domain || hostname.endsWith(`.${domain}`)) {
+        whitelisted = true
+      }
+    })
+    return whitelisted
+  } catch (error) {
+    return false
+  }
+}
+
+/* exempted URLs are displayed as written (but not linked) */
+export const isExempted = (url?: string) => {
+  const exempted = ["terra.py"]
+  if (!url) return false
+
+  return exempted.includes(url.toLowerCase())
+}
+
+/* match url-like references */
+export const URL_REGEX =
+  /((?:[a-z0-9-.]*?:\/\/)?(?:[^\s/]+\.[^\s.!?,)\d]{2,}|(?:(?:25[0-5]|2[0-4]\d|[01]?\d{1,2})\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d{1,2})|\[(?:[0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}\])(?:\S(?=[^\s.!?,)])|[^\s.!?,)])*)/gi


### PR DESCRIPTION
This PR brings forward the external URL warning system for proposal descriptions as implemented on the former TerraStation platform, while modifying behavior slightly to accommodate interchain (updating whitelists to reflect common discussion platforms for current chains, and changing text verbiage to reflect URLs external to Station rather than external to the Terra ecosystem).

Specifically, this PR introduces the following changes:

* For any URL (actual or potentially obfuscated) in a proposal description, instead display [external link] with a tooltip explaining why the URL was not displayed
* For proposals with detected external URLs, allow users to view the original proposal description selecting a "view original" checkbox displayed below the description
* For proposals with detected external URLs, display reminders about the importance of securing mnemonics and private keys
* Displays live warning message when URLs are detected on the SubmitProposalForm indicating that URLs will not be displayed as written when viewed via Station

This PR supersedes PR #159 and fixes #198 