### PR TITLE
Fix(gov): reverse proposal queries to correct missing recent gov proposals on classic due to number of proposals exceeding LAZY_LIMIT

### DIFF
--- a/src/data/queries/gov.ts
+++ b/src/data/queries/gov.ts
@@ -52,6 +52,7 @@ export const useProposals = (status: Proposal.Status) => {
         chainList.map((chainID) =>
           lcd.gov.proposals(chainID, {
             proposal_status: status,
+            "pagination.reverse": "true",
             ...Pagination,
           })
         )


### PR DESCRIPTION
The number of rejected proposals on the classic chain exceeds LAZY_LIMIT. Because the proposals are fetched in ascending order, the most recent proposals are not visible.

Pending a more formal implementation of pagination (currently investigating options for interchain), fetching proposals in reverse order from the backing API resolves the issue temporarily, but does limit visibility of very old proposals.

This PR defaults the proposal query to use reverse ordered pagination by default.