### PR TITLE
Constrain `mirror` function input to only accept objects

### DIFF
--- a/src/data/query.ts
+++ b/src/data/query.ts
@@ -21,7 +21,7 @@ export const combineState = (...results: QueryState[]) => ({
 })
 
 /* queryKey */
-const mirror = <T>(obj: T, parentKey?: string): T =>
+const mirror = <T extends object>(obj: T, parentKey?: string): T =>
   Object.entries(obj).reduce((acc, [key, value]) => {
     const next = value
       ? mirror(value, key)


### PR DESCRIPTION
This PR fixes the following type error:

![Screenshot 2023-02-02 at 3 24 27 PM](https://user-images.githubusercontent.com/32605822/216249093-b4e599ab-80a8-4ac8-9cc5-93606a83806f.png)

```
No overload matches this call.
  Overload 1 of 2, '(o: { [s: string]: unknown; } | ArrayLike<unknown>): [string, unknown][]', gave the following error.
    Argument of type 'T' is not assignable to parameter of type '{ [s: string]: unknown; } | ArrayLike<unknown>'.
      Type 'T' is not assignable to type 'ArrayLike<unknown>'.
  Overload 2 of 2, '(o: {}): [string, any][]', gave the following error.
    Argument of type 'T' is not assignable to parameter of type '{}'.
```