### PR TITLE
Offbeta/fixed tfm pricing

### DIFF
--- a/src/data/queries/coingecko.ts
+++ b/src/data/queries/coingecko.ts
@@ -73,7 +73,7 @@ export const useExchangeRates = () => {
           })(),
         ])
 
-      const holder = Object.fromEntries(
+      const priceObject = Object.fromEntries(
         Object.entries(prices).map(([denom, { usd, change24h }]) => {
           // if token is LUNA and network is classic, use LUNC price
           if (denom === "uluna" && isClassic) {
@@ -97,14 +97,14 @@ export const useExchangeRates = () => {
       )
 
       Object.entries(TFM_IDs).forEach(([key, value]) => {
-        if (!holder[key] && holder[value]) {
-          holder[key] = {
-            ...holder[value],
+        if (!priceObject[key] && priceObject[value]) {
+          priceObject[key] = {
+            ...priceObject[value],
           }
         }
       })
 
-      return holder
+      return priceObject
     },
     { ...RefetchOptions.DEFAULT }
   )

--- a/src/data/queries/coingecko.ts
+++ b/src/data/queries/coingecko.ts
@@ -1,7 +1,7 @@
 import { useCallback } from "react"
 import { useQuery } from "react-query"
 import { queryKey, RefetchOptions } from "../query"
-import { CURRENCY_KEY, STATION_ASSETS } from "config/constants"
+import { CURRENCY_KEY, STATION_ASSETS, ASSETS } from "config/constants"
 import axios from "axios"
 import { useCurrency } from "data/settings/Currency"
 import { useNetworkName } from "data/wallet"
@@ -52,24 +52,28 @@ export const useExchangeRates = () => {
   return useQuery(
     [queryKey.coingecko.exchangeRates, currency, isClassic],
     async () => {
-      const [{ data: prices }, fiatPrice] = await Promise.all([
-        axios.get<Record<string, TFMPrice>>(
-          `https://price.api.tfm.com/tokens/?limit=1500`
-        ),
-        (async () => {
-          if (currency.id === "USD") return 1
+      const [{ data: TFM_IDs }, { data: prices }, fiatPrice] =
+        await Promise.all([
+          axios.get<Record<string, string>>("station/tfm.json", {
+            baseURL: ASSETS,
+          }),
+          axios.get<Record<string, TFMPrice>>(
+            `https://price.api.tfm.com/tokens/?limit=1500`
+          ),
+          (async () => {
+            if (currency.id === "USD") return 1
 
-          const { data } = await axios.get<{
-            quotes: Record<string, number>
-          }>(
-            `https://apilayer.net/api/live?source=USD&currencies=${currency.id}&access_key=${CURRENCY_KEY}`
-          )
+            const { data } = await axios.get<{
+              quotes: Record<string, number>
+            }>(
+              `https://apilayer.net/api/live?source=USD&currencies=${currency.id}&access_key=${CURRENCY_KEY}`
+            )
 
-          return data?.quotes?.[`USD${currency.id}`] ?? 1
-        })(),
-      ])
+            return data?.quotes?.[`USD${currency.id}`] ?? 1
+          })(),
+        ])
 
-      return Object.fromEntries(
+      const holder = Object.fromEntries(
         Object.entries(prices).map(([denom, { usd, change24h }]) => {
           // if token is LUNA and network is classic, use LUNC price
           if (denom === "uluna" && isClassic) {
@@ -91,6 +95,16 @@ export const useExchangeRates = () => {
           ]
         })
       )
+
+      Object.entries(TFM_IDs).forEach(([key, value]) => {
+        if (!holder[key] && holder[value]) {
+          holder[key] = {
+            ...holder[value],
+          }
+        }
+      })
+
+      return holder
     },
     { ...RefetchOptions.DEFAULT }
   )


### PR DESCRIPTION
For ukuji TFM returns its IBC and in station, we see it as 'ukuji' for token and denom. So, when we get the price from `useExchangeRates` we look for `ukuji` and that doesn't exist. 

This fix gets  `tfm.json` in `station-assets` which has denoms we used mapped to IBCs and those get added to the prices Object so we can use them as we need.