### PR TITLE
fix(finderlink): correct terra classic finder link (was defaulting to mintscan for terra classic chain)

### DIFF
--- a/src/components/general/FinderLink.tsx
+++ b/src/components/general/FinderLink.tsx
@@ -71,7 +71,7 @@ const FinderLink = forwardRef(
             marsPath,
             value,
           ].join("/")
-        : chainName === "terra" || chainName === "classic"
+        : chainName === "terra" || chainName === "terra classic"
         ? [FINDER, networkName, finderPath, value].join("/")
         : [MINTSCAN, chainName, interchainPath, value].join("/")
 


### PR DESCRIPTION
FinderLink output for the Classic chain was resulting in mintscan links. Fix to properly reflect classic links via terrascope.