### PR TITLE
fix: error check

### DIFF
--- a/src/components/feedback/Fetching.tsx
+++ b/src/components/feedback/Fetching.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren, ReactNode, useState } from "react"
 import LinearProgress from "@mui/material/LinearProgress"
-import { getErrorMessage } from "utils/error"
+import { getErrorMessage, isError } from "utils/error"
 import useTimeout from "utils/hooks/useTimeout"
 import { Card } from "../layout"
 import Wrong from "./Wrong"
@@ -37,7 +37,7 @@ export const WithFetching = (props: WithFetchingProps) => {
             sx={{ position: "absolute" /* to overwrite */ }}
           />
         ) : undefined,
-        error ? <Wrong>{getErrorMessage(error)}</Wrong> : undefined
+        isError(error) ? <Wrong>{getErrorMessage(error)}</Wrong> : undefined
       )}
     </>
   )

--- a/src/components/feedback/Fetching.tsx
+++ b/src/components/feedback/Fetching.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren, ReactNode, useState } from "react"
 import LinearProgress from "@mui/material/LinearProgress"
-import { getErrorMessage, isError } from "utils/error"
+import { getErrorMessage } from "utils/error"
 import useTimeout from "utils/hooks/useTimeout"
 import { Card } from "../layout"
 import Wrong from "./Wrong"
@@ -37,7 +37,13 @@ export const WithFetching = (props: WithFetchingProps) => {
             sx={{ position: "absolute" /* to overwrite */ }}
           />
         ) : undefined,
-        isError(error) ? <Wrong>{getErrorMessage(error)}</Wrong> : undefined
+        error &&
+          !(
+            Object.getPrototypeOf(error) === Object.prototype &&
+            Object.keys(error).length === 0
+          ) ? (
+          <Wrong>{getErrorMessage(error)}</Wrong>
+        ) : undefined
       )}
     </>
   )

--- a/src/components/feedback/Fetching.tsx
+++ b/src/components/feedback/Fetching.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren, ReactNode, useState } from "react"
 import LinearProgress from "@mui/material/LinearProgress"
-import { getErrorMessage } from "utils/error"
+import { getErrorMessage, isError } from "utils/error"
 import useTimeout from "utils/hooks/useTimeout"
 import { Card } from "../layout"
 import Wrong from "./Wrong"
@@ -37,13 +37,7 @@ export const WithFetching = (props: WithFetchingProps) => {
             sx={{ position: "absolute" /* to overwrite */ }}
           />
         ) : undefined,
-        error &&
-          !(
-            Object.getPrototypeOf(error) === Object.prototype &&
-            Object.keys(error).length === 0
-          ) ? (
-          <Wrong>{getErrorMessage(error)}</Wrong>
-        ) : undefined
+        isError(error) ? <Wrong>{getErrorMessage(error)}</Wrong> : undefined
       )}
     </>
   )

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosError } from "axios"
 
-export const getErrorMessage = (
-  error?: Error | AxiosError | unknown
+const getErrorMessage = (
+  error?: Error | AxiosError | object | unknown
 ): string | undefined => {
   if (!error) return
 
@@ -10,3 +10,17 @@ export const getErrorMessage = (
 
   if (error instanceof Error) return error.message
 }
+
+const isError = (error?: Error | AxiosError | object | unknown): boolean => {
+  if (
+    !error ||
+    (Object.getPrototypeOf(error) === Object.prototype &&
+      Object.keys(error).length === 0)
+  ) {
+    return false
+  } else {
+    return true
+  }
+}
+
+export { getErrorMessage, isError }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosError } from "axios"
 
-export const getErrorMessage = (
-  error?: Error | AxiosError | unknown
+const getErrorMessage = (
+  error?: Error | AxiosError | object | unknown
 ): string | undefined => {
   if (!error) return
 
@@ -10,3 +10,17 @@ export const getErrorMessage = (
 
   if (error instanceof Error) return error.message
 }
+
+const isError = (error?: Error | AxiosError | object | unknown): boolean => {
+  if (
+    !error ||
+    (Object.getPrototypeOf(error) === Object.prototype &&
+      Object.keys(error as object).length === 0)
+  ) {
+    return false
+  } else {
+    return true
+  }
+}
+
+export { getErrorMessage, isError }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosError } from "axios"
 
-const getErrorMessage = (
-  error?: Error | AxiosError | object | unknown
+export const getErrorMessage = (
+  error?: Error | AxiosError | unknown
 ): string | undefined => {
   if (!error) return
 
@@ -10,17 +10,3 @@ const getErrorMessage = (
 
   if (error instanceof Error) return error.message
 }
-
-const isError = (error?: Error | AxiosError | object | unknown): boolean => {
-  if (
-    !error ||
-    (Object.getPrototypeOf(error) === Object.prototype &&
-      Object.keys(error).length === 0)
-  ) {
-    return false
-  } else {
-    return true
-  }
-}
-
-export { getErrorMessage, isError }


### PR DESCRIPTION
Adding `isError` utility function to evaluate if `error` value is true or false.  Currently, values of `error` that are empty objects are returning as true when they should be false.  `isError` includes this empty object check.