### PR TITLE
Bump terra.js package to v3.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@terra-money/feather.js": "^1.0.0-beta.11",
     "@terra-money/ledger-station-js": "^1.3.7",
     "@terra-money/log-finder-ruleset": "^3.0.0",
-    "@terra-money/terra.js": "^3.1.7",
+    "@terra-money/terra.js": "^3.1.8",
     "@terra-money/terra.proto": "^2.0.0",
     "@terra-money/use-wallet": "^4.0.0-beta.3",
     "@terra-money/wallet-provider": "^4.0.0-beta.3",


### PR DESCRIPTION
This PR will bump stations Terra.js NPM dependency to v3.1.8 in our package.json. This version includes the recent upstream changes L1TF merged into Terra.js via this PR @ https://github.com/terra-money/terra.js/pull/348 :smile:

Please make sure you release the new NPM package version  before you merge this PR. :pray: