### PR TITLE
fix: error checking

### DIFF
--- a/src/components/feedback/Fetching.tsx
+++ b/src/components/feedback/Fetching.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren, ReactNode, useState } from "react"
 import LinearProgress from "@mui/material/LinearProgress"
-import { getErrorMessage } from "utils/error"
+import { getErrorMessage, isError } from "utils/error"
 import useTimeout from "utils/hooks/useTimeout"
 import { Card } from "../layout"
 import Wrong from "./Wrong"
@@ -37,7 +37,7 @@ export const WithFetching = (props: WithFetchingProps) => {
             sx={{ position: "absolute" /* to overwrite */ }}
           />
         ) : undefined,
-        error ? <Wrong>{getErrorMessage(error)}</Wrong> : undefined
+        isError(error) ? <Wrong>{getErrorMessage(error)}</Wrong> : undefined
       )}
     </>
   )

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -3,15 +3,20 @@ import axios, { AxiosError } from "axios"
 export const getErrorMessage = (
   error?: Error | AxiosError | object | unknown
 ): string | undefined => {
-  if (
-    !error ||
-    (Object.getPrototypeOf(error) === Object.prototype &&
-      Object.keys(error as object).length === 0)
-  )
-    return
+  if (!isError(error)) return
 
   if (axios.isAxiosError(error))
     return (error as AxiosError<any>).response?.data?.message ?? error.message
 
   if (error instanceof Error) return error.message
+}
+
+export const isError = (
+  error?: Error | AxiosError | object | unknown
+): boolean => {
+  if (!error || JSON.stringify(error) === "{}") {
+    return false
+  } else {
+    return true
+  }
 }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,9 +1,14 @@
 import axios, { AxiosError } from "axios"
 
 export const getErrorMessage = (
-  error?: Error | AxiosError | unknown
+  error?: Error | AxiosError | object | unknown
 ): string | undefined => {
-  if (!error) return
+  if (
+    !error ||
+    (Object.getPrototypeOf(error) === Object.prototype &&
+      Object.keys(error as object).length === 0)
+  )
+    return
 
   if (axios.isAxiosError(error))
     return (error as AxiosError<any>).response?.data?.message ?? error.message


### PR DESCRIPTION
Error received may be empty object which is truthy in JavaScript.  Check for falsy values OR empty objects when deciding if an error is truthy.