### PR TITLE
fix: settings display chains

### DIFF
--- a/src/data/queries/chains.ts
+++ b/src/data/queries/chains.ts
@@ -50,11 +50,16 @@ export function getChainNamefromID(
   id: string | undefined,
   chains: Record<string, InterchainNetwork>
 ) {
-  return (
+  const chainName =
     Object.values(chains)
       .find(({ chainID }) => chainID === id)
       ?.name.toLowerCase() ?? ""
-  )
+
+  const titleCasedChainName = chainName.replace(/\w\S*/g, function (txt) {
+    return txt.charAt(0).toUpperCase() + txt.substring(1).toLowerCase()
+  })
+
+  return titleCasedChainName
 }
 
 export const getTruncateChainList = (
@@ -64,7 +69,6 @@ export const getTruncateChainList = (
   toShow: chainList.slice(0, toShowLength),
   rest: chainList.slice(toShowLength),
 })
-
 export const getDisplayChainsSettingLabel = (
   displayChains: string[],
   chains: Record<string, InterchainNetwork>
@@ -74,7 +78,10 @@ export const getDisplayChainsSettingLabel = (
     (arr) => JSON.stringify(arr) === JSON.stringify(displayChains)
   )
     ? "Default"
-    : toShow.map((chainID) => getChainNamefromID(chainID, chains)).join(", ") +
+    : toShow
+        .map((chainID) => getChainNamefromID(chainID, chains))
+        .filter((chain) => chain)
+        .join(", ") +
         (rest.length > 0
           ? ` & ${rest.length} other${rest.length === 1 ? "" : "s"}`
           : "")


### PR DESCRIPTION
Updating `Display chains` Setting to display only available chains in title casing.

# Before
<img width="628" alt="image" src="https://user-images.githubusercontent.com/30275692/236796119-23659790-e8c4-4b57-a8c2-d00ef07dab68.png">

# After
<img width="624" alt="image" src="https://user-images.githubusercontent.com/30275692/236796197-8d1b9335-69ff-4ee0-80ea-ca328b1802f3.png">
