### PR TITLE
React to classic-agora sunset (adds additional forums to external url whitelist)

### DIFF
--- a/src/pages/gov/ProposalDescription.tsx
+++ b/src/pages/gov/ProposalDescription.tsx
@@ -118,12 +118,14 @@ const ProposalDescription = ({ proposal }: { proposal: ProposalResult }) => {
 export default ProposalDescription
 
 function isLinkSafe(url: string) {
-  console.log(url)
   try {
     const { protocol, hostname } = new URL(url)
     return (
       protocol === "https:" &&
-      (hostname === "terra.money" || hostname.endsWith(".terra.money"))
+      (hostname === "terra.money" ||
+        hostname.endsWith(".terra.money") ||
+        hostname === "commonwealth.im" ||
+        hostname === "forums.terrarebels.net")
     )
   } catch (e) {
     return false


### PR DESCRIPTION
Update isLinkSafe to whitelist external links to commonwealth.im and forums.terrarebels.net. If this is not merged in its entirety, please consider at least including commonwealth.im as this would benefit multiple chains.