### PR TITLE
Fix tokens that contain :

### DIFF
--- a/src/app/InitBankBalance.tsx
+++ b/src/app/InitBankBalance.tsx
@@ -30,7 +30,8 @@ const InitBankBalance = ({ children }: PropsWithChildren<{}>) => {
   )
 
   native.list.forEach(({ id }) => {
-    const [chain, denom] = id.split(":")
+    const [chain, ...denomData] = id.split(":")
+    const denom = denomData.join(":")
     if (
       !bankBalance.find(
         (balance) => balance.denom === denom && balance.chain === chain

--- a/src/pages/wallet/AssetList.tsx
+++ b/src/pages/wallet/AssetList.tsx
@@ -77,7 +77,7 @@ const AssetList = () => {
               // @ts-expect-error
               unknownIBCDenoms[denom]?.chainID ?? data.chainID ?? chain,
               data.token,
-            ].join(":")
+            ].join("*")
 
             if (acc[key]) {
               acc[key].balance = `${

--- a/src/pages/wallet/AssetPage.tsx
+++ b/src/pages/wallet/AssetPage.tsx
@@ -21,8 +21,8 @@ const AssetPage = () => {
   const { t } = useTranslation()
   const { setRoute, route } = useWalletRoute()
   const routeDenom = route.path === Path.coin ? route.denom ?? "uluna" : "uluna"
-  const [chain, denom] = routeDenom.includes(":")
-    ? routeDenom.split(":")
+  const [chain, denom] = routeDenom.includes("*")
+    ? routeDenom.split("*")
     : [undefined, routeDenom]
   const { token, symbol, icon, decimals } = readNativeDenom(denom, chain)
 


### PR DESCRIPTION
This PR fixes the visualization of tokens whose denom contains `:`, like Kujira's factory tokens.

Before:
![Screenshot 2023-06-07 at 20 35 52](https://github.com/terra-money/station/assets/54709706/80cf5907-51a2-447c-bcec-767561418982)

After:
![Screenshot 2023-06-07 at 20 38 13](https://github.com/terra-money/station/assets/54709706/a80e58f1-b4cd-4d7d-8057-36498c065a25)
