### PR TITLE
add localterra to display chains

### DIFF
--- a/src/utils/localStorage/keys.ts
+++ b/src/utils/localStorage/keys.ts
@@ -42,6 +42,7 @@ export const DefaultDisplayChains = {
   mainnet: ["phoenix-1", "osmosis-1"],
   testnet: ["pisco-1"],
   classic: ["columbus-5"],
+  localterra: ["localterra"],
 }
 
 export const DefaultCustomTokens = {


### PR DESCRIPTION
The station doesn't work with Localterra anymore because it's missing "localterra" entry in DefaultDisplayChains.

![image](https://github.com/terra-money/station/assets/25343132/b66c7504-b20c-4374-992e-635c829a78e1)
