### PR TITLE
fix: add scroll to chainlist container

### DIFF
--- a/src/pages/wallet/AssetPage.module.scss
+++ b/src/pages/wallet/AssetPage.module.scss
@@ -25,6 +25,7 @@
 .chainlist__container {
   padding-top: 25px;
   padding-bottom: 1.6rem;
+  overflow-y: auto;
 }
 
 .chainlist {


### PR DESCRIPTION
## Before
When selecting an asset to view details, bottom of container is unreachable.
<img width="486" alt="0" src="https://github.com/terra-money/station/assets/17463738/a96b852d-f4f7-4599-bb93-71b8dc80b813">

## After
Added scroll to center container to allow header and actions to remain.
<img width="494" alt="1" src="https://github.com/terra-money/station/assets/17463738/af4c71cc-3d3b-47df-8e76-d02799476320">
<img width="515" alt="2" src="https://github.com/terra-money/station/assets/17463738/107d8553-8795-431c-9a4d-b936aebe91f1">
