### PR TITLE
feat: filter out non-whitelisted tokens

### DIFF
--- a/src/txs/swap/TFMSwapContext.tsx
+++ b/src/txs/swap/TFMSwapContext.tsx
@@ -127,7 +127,8 @@ const TFMSwapContext = ({ children }: PropsWithChildren<{}>) => {
             ...readNativeDenom(token),
             token: ibc,
             balance: getAmount(bankBalance, token),
-          })),
+          }))
+          .filter((entry) => (entry.isNonWhitelisted ? false : true)),
       ],
     }
 


### PR DESCRIPTION
## Before
non-whitelisted ibc tokens were showing up as blank choices in the askAsset field
![image](https://github.com/terra-money/station/assets/17463738/700254ef-be8a-4cec-92b7-e72e2ee76d45)

## After
askAsset field has non-whitelisted items filtered out at the fetch level
<img width="685" alt="image" src="https://github.com/terra-money/station/assets/17463738/c753e8f3-26a6-450f-ae07-9524a70cc5ab">
