### PR TITLE
hotfix: decouple ibc lunc from luna

### DIFF
--- a/src/pages/wallet/AssetPage.module.scss
+++ b/src/pages/wallet/AssetPage.module.scss
@@ -25,6 +25,7 @@
 .chainlist__container {
   padding-top: 25px;
   padding-bottom: 1.6rem;
+  overflow-y: auto;
 }
 
 .chainlist {

--- a/src/pages/wallet/AssetPage.tsx
+++ b/src/pages/wallet/AssetPage.tsx
@@ -60,7 +60,7 @@ const AssetPage = () => {
     if (chain) {
       return (
         unknownIBCDenoms[b.denom]?.baseDenom === token &&
-        unknownIBCDenoms[b.denom]?.chains.includes(chain)
+        unknownIBCDenoms[b.denom]?.chains?.includes(chain)
       )
     }
 

--- a/src/pages/wallet/AssetPage.tsx
+++ b/src/pages/wallet/AssetPage.tsx
@@ -1,17 +1,17 @@
-import { useNativeDenoms } from "data/token"
-import { useWalletRoute, Path } from "./Wallet"
-import styles from "./AssetPage.module.scss"
-import { Read, TokenIcon } from "components/token"
-import { useCurrency } from "data/settings/Currency"
-import { useExchangeRates } from "data/queries/coingecko"
-import { useBankBalance } from "data/queries/bank"
-import AssetChain from "./AssetChain"
-import { Button } from "components/general"
-import { useTranslation } from "react-i18next"
 import { capitalize } from "@mui/material"
-import Vesting from "./Vesting"
-import { isTerraChain } from "utils/chain"
+import { useTranslation } from "react-i18next"
+import { Button } from "components/general"
+import { Read, TokenIcon } from "components/token"
+import { useBankBalance } from "data/queries/bank"
+import { useExchangeRates } from "data/queries/coingecko"
 import { useIBCBaseDenoms } from "data/queries/ibc"
+import { useCurrency } from "data/settings/Currency"
+import { useNativeDenoms } from "data/token"
+import { isTerraChain } from "utils/chain"
+import AssetChain from "./AssetChain"
+import styles from "./AssetPage.module.scss"
+import Vesting from "./Vesting"
+import { Path, useWalletRoute } from "./Wallet"
 
 const AssetPage = () => {
   const currency = useCurrency()
@@ -55,9 +55,17 @@ const AssetPage = () => {
     {} as Record<string, { baseDenom: string; chains: string[] }>
   )
 
-  const filteredUnsupportedBalances = balances.filter(
-    (b) => unknownIBCDenoms[b.denom]?.baseDenom === token
-  )
+  const filteredUnsupportedBalances = balances.filter((b) => {
+    // only return unsupported token if the current chain is found in the ibc path
+    if (chain) {
+      return (
+        unknownIBCDenoms[b.denom]?.baseDenom === token &&
+        unknownIBCDenoms[b.denom]?.chains.includes(chain)
+      )
+    }
+
+    return unknownIBCDenoms[b.denom]?.baseDenom === token
+  })
 
   const totalBalance = [
     ...filteredBalances,


### PR DESCRIPTION
## Before
if the underlying token matches current token, show it.
<img width="402" alt="image" src="https://github.com/terra-money/station/assets/17463738/78b9f281-5754-4243-bb75-410cff77f643">

## After
both underlying token AND chain in path must match current token + chain

## Testing
- send lunc to osmosis using https://frontier.osmosis.zone
- go to wallet page and click "luna"
- before change, you will have the option to send lunc back, but it will have luna value assigned
- after change, ibc tokens without matching chains won't appear