### PR TITLE
ST-582: show disabled networks name and icon on the asset page

### DIFF
--- a/src/pages/wallet/AssetChain.tsx
+++ b/src/pages/wallet/AssetChain.tsx
@@ -10,6 +10,7 @@ import { CopyIcon, InternalButton } from "components/general"
 import { Tooltip } from "components/display"
 import { useDevMode } from "utils/localStorage"
 import { truncate } from "@terra-money/terra-utils"
+import { useNetworks } from "app/InitNetworks"
 
 export interface Props {
   chain: string
@@ -29,11 +30,12 @@ const AssetChain = (props: Props) => {
   const { data: prices, ...pricesState } = useExchangeRates()
   const { t } = useTranslation()
   const networkName = useNetworkName()
+  const allNetworks = useNetworks().networks[networkName]
 
   const networks = useNetwork()
   const { devMode } = useDevMode()
 
-  const { icon, name } = networks[chain] || {}
+  const { icon, name } = allNetworks[chain] ?? { name: chain }
 
   let price
   if (symbol === "LUNC" && networkName !== "classic") {
@@ -77,7 +79,7 @@ const AssetChain = (props: Props) => {
                   chainID={chain}
                   token={ibcDenom}
                   title={`Send ${symbol} back to ${
-                    networks[path[0]]?.name ?? path[0]
+                    allNetworks[path[0]]?.name ?? path[0]
                   }`}
                 >
                   {(open) => (
@@ -92,7 +94,9 @@ const AssetChain = (props: Props) => {
                 </IbcSendBack>
               ))}
           </h4>
-          {path && <p>{path.map((c) => networks[c]?.name ?? c).join(" → ")}</p>}
+          {path && (
+            <p>{path.map((c) => allNetworks[c]?.name ?? c).join(" → ")}</p>
+          )}
           {devMode && (
             <p>
               <span className={styles.copy__denom}>


### PR DESCRIPTION
See [linked jira issue](https://terra-money.atlassian.net/browse/ST-582) for details.

Before:
![Screenshot 2023-07-05 at 11 13 33](https://github.com/terra-money/station/assets/54709706/db8dac89-8cd5-4745-99b3-00ca6f49841a)

After:
![Screenshot 2023-07-05 at 11 12 23](https://github.com/terra-money/station/assets/54709706/9cad882a-213f-4fb0-b6ea-f49505fb5878)

