### PR TITLE
fix: undefined prices

### DIFF
--- a/src/data/queries/coingecko.ts
+++ b/src/data/queries/coingecko.ts
@@ -135,7 +135,7 @@ export const useMemoizedCalcValue = () => {
   return useCallback<CalcValue>(
     ({ amount, denom }) => {
       if (!memoizedPrices) return
-      return Number(amount) * Number(memoizedPrices[denom].price ?? 0)
+      return Number(amount) * Number(memoizedPrices[denom]?.price ?? 0)
     },
     [memoizedPrices]
   )


### PR DESCRIPTION
`ncheq` not available in price list.  Protect against denoms not being available in memoizedPrices.