### PR TITLE
fix kujira factory IBC tokens

### DIFF
--- a/src/data/queries/ibc.ts
+++ b/src/data/queries/ibc.ts
@@ -93,7 +93,6 @@ export const useIBCBaseDenoms = (data: { denom: Denom; chainID: string }[]) => {
             chains.unshift(data.identified_client_state.client_state.chain_id)
           }
 
-          console.log(base_denom)
           return {
             ibcDenom: denom,
             baseDenom: base_denom.startsWith("cw20:")
@@ -114,7 +113,10 @@ export const useIBCBaseDenoms = (data: { denom: Denom; chainID: string }[]) => {
 }
 
 export function calculateIBCDenom(baseDenom: string, path: string) {
-  if (!path) return baseDenom
+  if (!path)
+    return baseDenom.startsWith("factory:")
+      ? baseDenom.replaceAll(":", "/")
+      : baseDenom
 
   const assetString = [
     path,

--- a/src/data/queries/ibc.ts
+++ b/src/data/queries/ibc.ts
@@ -93,10 +93,14 @@ export const useIBCBaseDenoms = (data: { denom: Denom; chainID: string }[]) => {
             chains.unshift(data.identified_client_state.client_state.chain_id)
           }
 
+          console.log(base_denom)
           return {
             ibcDenom: denom,
             baseDenom: base_denom.startsWith("cw20:")
               ? base_denom.replace("cw20:", "")
+              : // fix for kujira factory tokens
+              base_denom.startsWith("factory:")
+              ? base_denom.replaceAll(":", "/")
               : base_denom,
             chainIDs: chains,
             channels,

--- a/src/pages/wallet/IbcSendBackTx.tsx
+++ b/src/pages/wallet/IbcSendBackTx.tsx
@@ -94,6 +94,7 @@ function IbcSendBackTx({ token, chainID }: Props) {
   const { errors } = formState
   const { input } = watch()
   const queryClient = useQueryClient()
+  const networks = useNetwork()
 
   const [step, setStep] = useState<number>(0)
   const [isLoading, setIsLoading] = useState<boolean>(false)
@@ -122,7 +123,7 @@ function IbcSendBackTx({ token, chainID }: Props) {
     }
   }
 
-  const isKujira = ibcDetails?.chainIDs[0] === "kaiyo-1"
+  const isKujira = networks[ibcDetails?.chainIDs[0] ?? ""]?.prefix === "kujira"
 
   useEffect(() => {
     // around 3 minutes with a 10 seconds interval

--- a/src/pages/wallet/IbcSendBackTx.tsx
+++ b/src/pages/wallet/IbcSendBackTx.tsx
@@ -122,6 +122,8 @@ function IbcSendBackTx({ token, chainID }: Props) {
     }
   }
 
+  const isKujira = ibcDetails?.chainIDs[0] === "kaiyo-1"
+
   useEffect(() => {
     // around 3 minutes with a 10 seconds interval
     let maxIterations = 18
@@ -160,7 +162,9 @@ function IbcSendBackTx({ token, chainID }: Props) {
     () =>
       ibcDetails &&
       calculateIBCDenom(
-        ibcDetails.baseDenom,
+        isKujira
+          ? ibcDetails.baseDenom?.replaceAll("/", ":")
+          : ibcDetails.baseDenom,
         ibcDetails.channels
           .slice(0, ibcDetails.channels.length - step)
           .reduce(
@@ -171,7 +175,7 @@ function IbcSendBackTx({ token, chainID }: Props) {
             ""
           )
       ),
-    [step, ibcDetails]
+    [step, ibcDetails, isKujira]
   )
 
   const chains = useMemo(
@@ -234,7 +238,9 @@ function IbcSendBackTx({ token, chainID }: Props) {
     onChangeMax,
     onPost: () => {
       const nextDenom = calculateIBCDenom(
-        ibcDetails?.baseDenom ?? "",
+        (isKujira
+          ? ibcDetails?.baseDenom?.replaceAll("/", ":")
+          : ibcDetails?.baseDenom) ?? "",
         (ibcDetails?.channels ?? [])
           .slice(0, (ibcDetails?.channels.length ?? 0) - step - 1)
           .reduce(


### PR DESCRIPTION
The problem with Kujira factory tokens was that on kujira they use `/` in the denom, but when they are transferred with IBC the denom hash is calculated from the basedenom with all `/` replaced by `:` (likely because[ older versions of IBC didn't support the `/` char in the base denom](https://tutorials.cosmos.network/tutorials/6-ibc-dev/#how-are-ibc-denoms-derived), and so they modified their IBC module).
I had to make some fixes both on station (this PR) and on station-assets.

