### PR TITLE
Dependency for terra.js updated to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@terra-money/ledger-terra-js": "^1.3.0",
     "@terra-money/log-finder-ruleset": "^3.0.0",
     "@terra-money/msg-reader": "^3.0.1",
-    "@terra-money/terra.js": "^3.1.7",
+    "@terra-money/terra.js": "^3.1.10",
     "@terra-money/terra.proto": "^2.0.0",
     "@terra-money/use-wallet": "^3.9.1",
     "@terra-money/wallet-controller": "^3.9.1",


### PR DESCRIPTION
This should resolve the issues with terra classic contract executions/queries in terra station mobile since the L1 changes/patches have been merged into terra.js 3.1.10