### PR TITLE
fix: staking rewards

### DIFF
--- a/src/data/queries/distribution.ts
+++ b/src/data/queries/distribution.ts
@@ -137,13 +137,3 @@ export const calcRewardsValues = (
 
   return { total, byValidator }
 }
-
-export const calcRewardsValuesForChain = (
-  rewards: Rewards | undefined,
-  currency: Denom
-) => {
-  if (!rewards) return []
-  return sortCoins(rewards?.total, currency).filter(({ amount }) => {
-    return has(amount)
-  })
-}

--- a/src/pages/stake/rewards/ChainRewards.tsx
+++ b/src/pages/stake/rewards/ChainRewards.tsx
@@ -48,6 +48,19 @@ const ChainRewards = ({ chain }: { chain: string }) => {
     chain === "phoenix-1" || chain === "pisco-1" || chain === "all"
       ? chainRewards.total.add(getCoinsFromRewards(allianceHubRewards))
       : chainRewards.total
+
+  // The delegation rewards are returned using sdk.DecCoins type which means that
+  // after the comma there is a fraction of unit of a token available follow:
+  // ref.
+  //  - https://github.com/terra-money/cosmos-sdk/blob/upgrade/v0.46.x-terra/x/distribution/keeper/grpc_query.go#L166 .
+  //  - https://github.com/terra-money/cosmos-sdk/blob/upgrade/v0.46.x-terra/x/staking/types/staking.pb.go#L592-L599
+  //
+  // Since the user cannnot claim a 1 utoken we filter out these values
+  // e.g. 0.000000065984338625uluna < 1uluna
+  totalChainRewardsList = totalChainRewardsList.filter((rew) =>
+    rew.amount.gte(1)
+  )
+
   // Find the current chain denom
   const selectedChainDenom = networks[chain]?.baseAsset
 
@@ -92,7 +105,7 @@ const ChainRewards = ({ chain }: { chain: string }) => {
       )}
     >
       <TokenCardGrid maxHeight>
-        {totalChainRewardsList?.map(({ amount, denom }) => (
+        {totalChainRewardsList.map(({ amount, denom }) => (
           <WithTokenItem token={denom} key={denom}>
             {(item) => (
               <TokenCard


### PR DESCRIPTION
This pull request deletes the unused function `calcRewardsValuesForChain` and fixes the staking rewards because they are returned using sdk.DecCoins type which means that after the comma there is a fraction of unit of a token available follow:
- https://github.com/terra-money/cosmos-sdk/blob/upgrade/v0.46.x-terra/x/distribution/keeper/grpc_query.go#L166
- https://github.com/terra-money/cosmos-sdk/blob/upgrade/v0.46.x-terra/x/staking/types/staking.pb.go#L592-L599
  
Since the user cannnot claim a 1 utoken we filter out these values
  e.g. 0.000000065984338625uluna < 1uluna


> There is another complementary pull request because some of the tokens were not showing in the list because they were missing from station-assets https://github.com/terra-money/station-assets/pull/195