### PR TITLE
hotfix: re-whitelist agora

### DIFF
--- a/src/pages/gov/ProposalDescription.tsx
+++ b/src/pages/gov/ProposalDescription.tsx
@@ -123,7 +123,7 @@ function isLinkSafe(url: string) {
     const { protocol, hostname } = new URL(url)
     return (
       protocol === "https:" &&
-      (hostname === "terra.dev" || hostname.endsWith(".terra.dev"))
+      (hostname.endsWith("terra.dev") || hostname.endsWith("terra.money"))
     )
   } catch (e) {
     return false


### PR DESCRIPTION
terra.money domains were replaced with terra.dev temporarily.  This pull will whitelist terra.money domains in governance proposals:

**Before:** https://station.money/proposal/phoenix-1/4785

**After:** https://hotfix-proposal-whitelist.station-1a1.pages.dev/proposal/phoenix-1/4785