### PR TITLE
feat: use multi-chain address for admin check

### DIFF
--- a/src/pages/contract/ContractItemActions.tsx
+++ b/src/pages/contract/ContractItemActions.tsx
@@ -1,15 +1,23 @@
 import { useTranslation } from "react-i18next"
-import { useAddress } from "data/wallet"
+import { useAddress, useNetwork } from "data/wallet"
+import { useInterchainAddresses } from "auth/hooks/useAddress"
 import { Button, LinkButton } from "components/general"
 import { ModalButton } from "components/feedback"
 import { ExtraActions } from "components/layout"
 import ContractQuery from "./ContractQuery"
 import { useContract } from "./Contract"
+import { getChainIDFromAddress } from "utils/bech32"
 
 const ContractItemActions = () => {
   const { t } = useTranslation()
-  const connectedAddress = useAddress()
+  const networks = useNetwork()
+  const terraAddress = useAddress()
+  const addresses = useInterchainAddresses()
   const { address, admin } = useContract()
+
+  const chainID = getChainIDFromAddress(address, networks)
+  const connectedAddress =
+    chainID && addresses?.[chainID] ? addresses[chainID] : terraAddress
 
   return (
     <ExtraActions>

--- a/src/pages/contract/ContractItemActions.tsx
+++ b/src/pages/contract/ContractItemActions.tsx
@@ -1,12 +1,12 @@
 import { useTranslation } from "react-i18next"
 import { useAddress, useNetwork } from "data/wallet"
 import { useInterchainAddresses } from "auth/hooks/useAddress"
+import { getChainIDFromAddress } from "utils/bech32"
+import { useContract } from "./Contract"
+import ContractQuery from "./ContractQuery"
 import { Button, LinkButton } from "components/general"
 import { ModalButton } from "components/feedback"
 import { ExtraActions } from "components/layout"
-import ContractQuery from "./ContractQuery"
-import { useContract } from "./Contract"
-import { getChainIDFromAddress } from "utils/bech32"
 
 const ContractItemActions = () => {
   const { t } = useTranslation()

--- a/src/txs/wasm/MigrateContractForm.tsx
+++ b/src/txs/wasm/MigrateContractForm.tsx
@@ -3,7 +3,9 @@ import { useTranslation } from "react-i18next"
 import { useForm } from "react-hook-form"
 import { AccAddress, MsgMigrateContract } from "@terra-money/feather.js"
 import { parseJSON, validateMsg } from "utils/data"
-import { useAddress, useChainID } from "data/wallet"
+import { useNetwork } from "data/wallet"
+import { useInterchainAddresses } from "auth/hooks/useAddress"
+import { getChainIDFromAddress } from "utils/bech32"
 import { Form, FormItem } from "components/form"
 import { Input, EditorInput } from "components/form"
 import validate from "../validate"
@@ -18,8 +20,10 @@ interface TxValues {
 const MigrateContractForm = ({ contract }: { contract: AccAddress }) => {
   const { t } = useTranslation()
 
-  const address = useAddress()
-  const chainID = useChainID()
+  const networks = useNetwork()
+  const addresses = useInterchainAddresses()
+  const chainID = getChainIDFromAddress(contract, networks) ?? ""
+  const address = addresses?.[chainID ?? ""]
 
   /* form */
   const form = useForm<TxValues>({ mode: "onChange" })

--- a/src/txs/wasm/UpdateAdminContractForm.tsx
+++ b/src/txs/wasm/UpdateAdminContractForm.tsx
@@ -2,9 +2,11 @@ import { useCallback, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { useForm } from "react-hook-form"
 import { AccAddress, MsgUpdateContractAdmin } from "@terra-money/feather.js"
-import { useAddress, useChainID } from "data/wallet"
+import { useNetwork } from "data/wallet"
+import { useInterchainAddresses } from "auth/hooks/useAddress"
 import { Form, FormItem } from "components/form"
 import { Input } from "components/form"
+import { getChainIDFromAddress } from "utils/bech32"
 import validate from "../validate"
 import Tx from "../Tx"
 
@@ -16,8 +18,10 @@ interface TxValues {
 const UpdateAdminContractForm = ({ contract }: { contract: AccAddress }) => {
   const { t } = useTranslation()
 
-  const address = useAddress()
-  const chainID = useChainID()
+  const networks = useNetwork()
+  const addresses = useInterchainAddresses()
+  const chainID = getChainIDFromAddress(contract, networks) ?? ""
+  const address = addresses?.[chainID ?? ""]
 
   /* form */
   const form = useForm<TxValues>({ mode: "onChange" })


### PR DESCRIPTION
- [x] set terra address as default
- [x] check network contract belongs to.
- [x] if there is a supported wallet address for network, check if admin 

## Before
![image](https://github.com/terra-money/station/assets/17463738/b328e9cf-05f1-45ee-be72-0f5285bf314c)

## After
<img width="1251" alt="image" src="https://github.com/terra-money/station/assets/17463738/1c67873c-cd6f-4aa6-bc4d-601c61bc99a4">
