### PR TITLE
use real values in estimation tx

### DIFF
--- a/src/txs/send/SendForm.tsx
+++ b/src/txs/send/SendForm.tsx
@@ -121,7 +121,7 @@ const SendForm = ({ token, decimals, balance }: Props) => {
   /* fee */
   const coins = [{ input, denom: token, taxRequired: true }] as CoinInput[]
   const estimationTxValues = useMemo(
-    () => ({ address: connectedAddress, input: toInput(1, decimals) }),
+    () => ({ address: connectedAddress, input: toInput(input ?? 1, decimals) }),
     [connectedAddress, decimals]
   )
 


### PR DESCRIPTION
Station mobile uses 1uluna to send gas estimation requests. This is too low to calculate gas which leads to very inaccurate gas estimates (tax involves kv store operations).